### PR TITLE
Use json.RawMessage for faster and cheaper JSON checks

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -202,7 +202,7 @@ func IsISBN(str string, version int) bool {
 
 // IsJSON check if the string is valid JSON (note: uses json.Unmarshal).
 func IsJSON(str string) bool {
-	var js map[string]interface{}
+	var js json.RawMessage
 	return json.Unmarshal([]byte(str), &js) == nil
 }
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -200,8 +200,8 @@ func TestIsByteLength(t *testing.T) {
 
 func TestIsJSON(t *testing.T) {
 	tests := []string{"", "145", "asdf", "123:f00", "{\"Name\":\"Alice\",\"Body\":\"Hello\",\"Time\":1294706395881547000}",
-		"{}", "{\"Key\":{\"Key\":{\"Key\":123}}}"}
-	expected := []bool{false, false, false, false, true, true, true}
+		"{}", "{\"Key\":{\"Key\":{\"Key\":123}}}", "[]", "null"}
+	expected := []bool{false, true, false, false, true, true, true, true, true}
 	for i := 0; i < len(tests); i++ {
 		result := IsJSON(tests[i])
 		if result != expected[i] {


### PR DESCRIPTION
This updates `IsJSON` to work with any JSON type, not just objects. Also using a `json.RawMessage` avoids unnecessary allocations and is generally faster.
