### PR TITLE
Fix Escape

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -86,18 +86,11 @@ func ReplacePattern(str, pattern, replace string) string {
 
 // Escape replace <, >, & and " with HTML entities.
 func Escape(str string) string {
-	escaped := str
-	escaping := map[string]string{}
-	escaping[`&`] = "&amp;"
-	escaping[`"`] = "&quot;"
-	escaping[`<`] = "&lt;"
-	escaping[`>`] = "&gt;"
-	// If you want to add more escaping characters,
-	// use escaping[old_char] = escaped_form
-	for key, value := range escaping {
-		escaped = strings.Replace(escaped, key, value, -1)
-	}
-	return escaped
+	str = strings.Replace(str, `&`, "&amp;", -1)
+	str = strings.Replace(str, `"`, "&quot;", -1)
+	str = strings.Replace(str, `<`, "&lt;", -1)
+	str = strings.Replace(str, `>`, "&gt;", -1)
+	return str
 }
 
 func addSegment(inrune, segment []rune) []rune {


### PR DESCRIPTION
There was a problem with Escape, which was causing test failures sometimes.

It relied on the order of items when `range`ing through a map, which is undefined. Thus, the order in which strings were replaced was undefined. In cases where `&` was not escaped first, it caused test failures because it replaced the `&` in entities like `&lt;`, turning them to `&amp&lt;`, etc.

This also gets rid of the map to avoid extra allocations, which makes the entire function faster, and avoids keeping track of the original variable since it is not needed.

Closes #9.
