### PR TITLE
Alias Escape to html.EscapeString

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package govalidator
 
 import (
 	"errors"
+	"html"
 	"path"
 	"regexp"
 	"strings"
@@ -85,13 +86,7 @@ func ReplacePattern(str, pattern, replace string) string {
 }
 
 // Escape replace <, >, & and " with HTML entities.
-func Escape(str string) string {
-	str = strings.Replace(str, `&`, "&amp;", -1)
-	str = strings.Replace(str, `"`, "&quot;", -1)
-	str = strings.Replace(str, `<`, "&lt;", -1)
-	str = strings.Replace(str, `>`, "&gt;", -1)
-	return str
-}
+var Escape = html.EscapeString
 
 func addSegment(inrune, segment []rune) []rune {
 	if len(segment) == 0 {

--- a/utils_test.go
+++ b/utils_test.go
@@ -148,7 +148,7 @@ func ExampleReplacePattern() {
 
 func TestEscape(t *testing.T) {
 	tests := []string{`<img alt="foo&bar">`}
-	expected := []string{"&lt;img alt=&quot;foo&amp;bar&quot;&gt;"}
+	expected := []string{"&lt;img alt=&#34;foo&amp;bar&#34;&gt;"}
 	for i := 0; i < len(tests); i++ {
 		res := Escape(tests[i])
 		if res != expected[i] {


### PR DESCRIPTION
[`html.EscapeString`](http://golang.org/pkg/html/#EscapeString) is [more complete](http://golang.org/src/pkg/html/escape.go?s=5317:5351#L219) and thus should be used instead.

This also closes #9, but it is based on top of #17, so merging this will also merge #17.
