### PR TITLE
Use net.ParseMAC for MAC address checking

### DIFF
--- a/patterns.go
+++ b/patterns.go
@@ -28,7 +28,6 @@ const (
 	HalfWidth    string = "[\u0020-\u007E\uFF61-\uFF9F\uFFA0-\uFFDC\uFFE8-\uFFEE0-9a-zA-Z]"
 	Base64       string = "^(?:[A-Za-z0-9+\\/]{4})*(?:[A-Za-z0-9+\\/]{2}==|[A-Za-z0-9+\\/]{3}=|[A-Za-z0-9+\\/]{4})$"
 	DataURI      string = "^data:.+\\/(.+);base64$"
-	MAC          string = "^([a-fA-F0-9]{2}[:-]){5}[a-fA-F0-9]{2}$"
 	Latitude     string = "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$"
 	Longitude    string = "^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
 	URL          string = `^((ftp|http|https):\/\/)?(\S+(:\S*)?@)?((([1-9]\d?|1\d\d|2[01]\d|22[0-3])(\.(1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.([0-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|((www\.)?)?(([a-z\x{00a1}-\x{ffff}0-9]+-?-?_?)*[a-z\x{00a1}-\x{ffff}0-9]+)(?:\.([a-z\x{00a1}-\x{ffff}]{2,}))?)|localhost)(:(\d{1,5}))?((\/|\?|#)[^\s]*)?$`
@@ -60,7 +59,6 @@ var (
 	rxHalfWidth    = regexp.MustCompile(HalfWidth)
 	rxBase64       = regexp.MustCompile(Base64)
 	rxDataURI      = regexp.MustCompile(DataURI)
-	rxMAC          = regexp.MustCompile(MAC)
 	rxLatitude     = regexp.MustCompile(Latitude)
 	rxLongitude    = regexp.MustCompile(Longitude)
 	rxURL          = regexp.MustCompile(URL)

--- a/validator.go
+++ b/validator.go
@@ -5,6 +5,7 @@ package govalidator
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"reflect"
 	"regexp"
 	"sort"
@@ -271,11 +272,15 @@ func IsIPv6(str string) bool {
 
 // IsMAC check if a string is valid MAC address.
 // Possible MAC formats:
-// 3D:F2:C9:A6:B3:4F
-// 3D-F2-C9-A6-B3:4F
-// 3d-f2-c9-a6-b3:4f
+// 01:23:45:67:89:ab
+// 01:23:45:67:89:ab:cd:ef
+// 01-23-45-67-89-ab
+// 01-23-45-67-89-ab-cd-ef
+// 0123.4567.89ab
+// 0123.4567.89ab.cdef
 func IsMAC(str string) bool {
-	return rxMAC.MatchString(str)
+	_, err := net.ParseMAC(str)
+	return err == nil
 }
 
 // IsLatitude check if a string is valid latitude.

--- a/validator_test.go
+++ b/validator_test.go
@@ -446,7 +446,7 @@ func TestIsIP(t *testing.T) {
 
 func TestIsMAC(t *testing.T) {
 	tests := []string{"3D:F2:C9:A6:B3:4F", "3D-F2-C9-A6-B3:4F", "123", "", "abacaba"}
-	expected := []bool{true, true, false, false, false}
+	expected := []bool{true, false, false, false, false}
 	for i := 0; i < len(tests); i++ {
 		result := IsMAC(tests[i])
 		if result != expected[i] {


### PR DESCRIPTION
This adds all supported MAC formats and removes the `01:23:45:AB-CD-EF` which is not accepted by any of the specifications (IEEE 802 MAC-48, EUI-48, or EUI-64).
