### PR TITLE
fixed bug where a slice of primitives would cause validate error

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -477,9 +477,18 @@ func typeCheck(v reflect.Value, t reflect.StructField) (bool, error) {
 		}
 		result := true
 		for i := 0; i < v.Len(); i++ {
-			resultItem, err := ValidateStruct(v.Index(i).Interface())
-			if err != nil {
-				return false, err
+			var resultItem bool
+			var err error
+			if v.Index(i).Kind() != reflect.Struct {
+				resultItem, err = typeCheck(v.Index(i), t)
+				if err != nil {
+					return false, err
+				}
+			} else {
+				resultItem, err = ValidateStruct(v.Index(i).Interface())
+				if err != nil {
+					return false, err
+				}
 			}
 			result = result && resultItem
 		}
@@ -487,9 +496,18 @@ func typeCheck(v reflect.Value, t reflect.StructField) (bool, error) {
 	case reflect.Array:
 		result := true
 		for i := 0; i < v.Len(); i++ {
-			resultItem, err := ValidateStruct(v.Index(i).Interface())
-			if err != nil {
-				return false, err
+			var resultItem bool
+			var err error
+			if v.Index(i).Kind() != reflect.Struct {
+				resultItem, err = typeCheck(v.Index(i), t)
+				if err != nil {
+					return false, err
+				}
+			} else {
+				resultItem, err = ValidateStruct(v.Index(i).Interface())
+				if err != nil {
+					return false, err
+				}
 			}
 			result = result && resultItem
 		}

--- a/validator_test.go
+++ b/validator_test.go
@@ -882,6 +882,8 @@ type User struct {
 type PrivateStruct struct {
 	privateField string `valid:"required,alpha,d_k"`
 	NonZero      int
+	ListInt      []int
+	ListString   []string `valid:"alpha"`
 	Work         [2]Address
 	Home         Address
 	Map          map[string]Address
@@ -934,7 +936,7 @@ func TestValidateStruct(t *testing.T) {
 	TagMap["d_k"] = Validator(func(str string) bool {
 		return str == "d_k"
 	})
-	result, err = ValidateStruct(PrivateStruct{"d_k", 0, [2]Address{Address{"Street", "123456"},
+	result, err = ValidateStruct(PrivateStruct{"d_k", 0, []int{1, 2}, []string{"hi", "super"}, [2]Address{Address{"Street", "123456"},
 		Address{"Street", "123456"}}, Address{"Street", "123456"}, map[string]Address{"address": Address{"Street", "123456"}}})
 	if result != true {
 		t.Log("Case ", 6, ": expected ", true, " when result is ", result)


### PR DESCRIPTION
So I found a particularly nasty bug where if you made a struct like so: 

```
type fooStruct struct {
    ListInt      []int
    ListString   []string 
}
```

The struct would fail validating even if you didn't add the "valid" tag to that field. In other words having a slice of primitives in a struct would make the struct always fail validation. 

Anyway the fix below should do it. It passes all the tests and I added new tests for slices of primitives. 
