### PR TITLE
Added U.S. Social Security Number validation

### DIFF
--- a/patterns.go
+++ b/patterns.go
@@ -29,6 +29,7 @@ const (
 	Latitude     string = "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$"
 	Longitude    string = "^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
 	URL          string = `^((ftp|http|https):\/\/)?(\S+(:\S*)?@)?((([1-9]\d?|1\d\d|2[01]\d|22[0-3])(\.(1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.([0-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|((www\.)?)?(([a-z\x{00a1}-\x{ffff}0-9]+-?-?_?)*[a-z\x{00a1}-\x{ffff}0-9]+)(?:\.([a-z\x{00a1}-\x{ffff}]{2,}))?)|localhost)(:(\d{1,5}))?((\/|\?|#)[^\s]*)?$`
+	SSN          string = `^\d{3}[- ]?\d{2}[- ]?\d{4}$`
 	tagName      string = "valid"
 )
 
@@ -58,4 +59,5 @@ var (
 	rxLatitude     = regexp.MustCompile(Latitude)
 	rxLongitude    = regexp.MustCompile(Longitude)
 	rxURL          = regexp.MustCompile(URL)
+	rxSSN          = regexp.MustCompile(SSN)
 )

--- a/types.go
+++ b/types.go
@@ -55,4 +55,5 @@ var TagMap = map[string]Validator{
 	"mac":           IsMAC,
 	"latitude":      IsLatitude,
 	"longitude":     IsLongitude,
+	"ssn":           IsSSN,
 }

--- a/validator.go
+++ b/validator.go
@@ -392,6 +392,14 @@ func isValidTag(s string) bool {
 	return true
 }
 
+// IsSSN will validate the given string as a U.S. Social Security Number
+func IsSSN(str string) bool {
+	if str == "" || len(str) != 11 {
+		return false
+	}
+	return rxSSN.MatchString(str)
+}
+
 // Contains returns whether checks that a comma-separated list of options
 // contains a particular substr flag. substr must be surrounded by a
 // string boundary or commas.

--- a/validator_test.go
+++ b/validator_test.go
@@ -609,8 +609,8 @@ func TestIsUUID(t *testing.T) {
 
 	// Tests without version
 	var tests = []struct {
-			param    string
-			expected bool
+		param    string
+		expected bool
 	}{
 		{"", false},
 		{"xxxa987fbc9-4bed-3078-cf07-9141ba07c9f3", false},
@@ -630,11 +630,11 @@ func TestIsUUID(t *testing.T) {
 
 	// UUID ver. 3
 	tests = []struct {
-			param    string
-			expected bool
+		param    string
+		expected bool
 	}{
 		{"", false},
-		{"412452646", false },
+		{"412452646", false},
 		{"xxxa987fbc9-4bed-3078-cf07-9141ba07c9f3", false},
 		{"a987fbc9-4bed-4078-8f07-9141ba07c9f3", false},
 		{"a987fbc9-4bed-3078-cf07-9141ba07c9f3", true},
@@ -648,10 +648,10 @@ func TestIsUUID(t *testing.T) {
 
 	// UUID ver. 4
 	tests = []struct {
-			param    string
-			expected bool
+		param    string
+		expected bool
 	}{
-		{"", false },
+		{"", false},
 		{"xxxa987fbc9-4bed-3078-cf07-9141ba07c9f3", false},
 		{"a987fbc9-4bed-5078-af07-9141ba07c9f3", false},
 		{"934859", false},
@@ -667,8 +667,8 @@ func TestIsUUID(t *testing.T) {
 
 	// UUID ver. 5
 	tests = []struct {
-			param    string
-			expected bool
+		param    string
+		expected bool
 	}{
 
 		{"", false},
@@ -715,7 +715,7 @@ func TestIsISBN(t *testing.T) {
 
 	// Without version
 	var tests = []struct {
-		param	 string
+		param    string
 		expected bool
 	}{
 		{"", false},
@@ -738,7 +738,7 @@ func TestIsISBN(t *testing.T) {
 
 	// ISBN 10
 	tests = []struct {
-		param	 string
+		param    string
 		expected bool
 	}{
 		{"", false},
@@ -761,7 +761,7 @@ func TestIsISBN(t *testing.T) {
 
 	// ISBN 13
 	tests = []struct {
-		param	 string
+		param    string
 		expected bool
 	}{
 		{"", false},
@@ -961,6 +961,26 @@ func TestIsLongitude(t *testing.T) {
 		actual := IsLongitude(test.param)
 		if actual != test.expected {
 			t.Errorf("Expected IsLongitude(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+	}
+}
+
+func TestIsSSN(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		param    string
+		expected bool
+	}{
+		{"00-90-8787", false},
+		{"66690-76", false},
+		{"191 60 2869", true},
+		{"191-60-2869", true},
+	}
+	for _, test := range tests {
+		actual := IsSSN(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected IsSSN(%q) to be %v, got %v", test.param, test.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
Addition matches U.S. Social Security Numbers.  Tests on what's able to be matched have been included in tests.
