### PR TITLE
Should fix the +- UTF bugs. 

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -110,8 +110,15 @@ func IsUTFNumeric(str string) bool {
 	if IsNull(str) {
 		return true
 	}
+	if strings.IndexAny(str, "+-") > 0 {
+		return false
+	}
+	if len(str) > 1 {
+		str = strings.TrimPrefix(str, "-")
+		str = strings.TrimPrefix(str, "+")
+	}
 	for _, c := range str {
-		if unicode.IsNumber(c) == false && c != '-' { //numbers && minus sign are ok
+		if unicode.IsNumber(c) == false { //numbers && minus sign are ok
 			return false
 		}
 	}
@@ -124,8 +131,15 @@ func IsUTFDigit(str string) bool {
 	if IsNull(str) {
 		return true
 	}
+	if strings.IndexAny(str, "+-") > 0 {
+		return false
+	}
+	if len(str) > 1 {
+		str = strings.TrimPrefix(str, "-")
+		str = strings.TrimPrefix(str, "+")
+	}
 	for _, c := range str {
-		if !unicode.IsDigit(c) && c != '-' { //digits && minus sign are ok
+		if !unicode.IsDigit(c) { //digits && minus sign are ok
 			return false
 		}
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -334,6 +334,8 @@ func TestIsUTFNumeric(t *testing.T) {
 		{"-00123", true},
 		{"0", true},
 		{"-0", true},
+		{"--0", false},
+		{"-0-", false},
 		{"123.123", false},
 		{" ", false},
 		{".", false},
@@ -348,6 +350,7 @@ func TestIsUTFNumeric(t *testing.T) {
 		{"1+1", false},
 		{"+", false},
 		{"++", false},
+		{"+1", true},
 	}
 	for _, test := range tests {
 		actual := IsUTFNumeric(test.param)
@@ -390,6 +393,8 @@ func TestIsUTFDigit(t *testing.T) {
 		{"-00123", true},
 		{"0", true},
 		{"-0", true},
+		{"--0", false},
+		{"-0-", false},
 		{"123.123", false},
 		{" ", false},
 		{".", false},
@@ -408,6 +413,7 @@ func TestIsUTFDigit(t *testing.T) {
 		{"1+1", false},
 		{"+", false},
 		{"++", false},
+		{"+1", true},
 	}
 	for _, test := range tests {
 		actual := IsUTFDigit(test.param)
@@ -439,7 +445,6 @@ func TestIsLowerCase(t *testing.T) {
 		{"S T R", false},
 		{"fooBar", false},
 		{"abacaba123", true},
-
 	}
 	for _, test := range tests {
 		actual := IsLowerCase(test.param)
@@ -487,16 +492,16 @@ func TestIsInt(t *testing.T) {
 		param    string
 		expected bool
 	}{
-		{"-2147483648", true}, //Signed 32 Bit Min Int
-		{"2147483647", true}, //Signed 32 Bit Max Int
-		{"-2147483649", true}, //Signed 32 Bit Min Int - 1
-		{"2147483648", true}, //Signed 32 Bit Max Int + 1
-		{"4294967295", true}, //Unsigned 32 Bit Max Int
-		{"4294967296", true}, //Unsigned 32 Bit Max Int + 1
+		{"-2147483648", true},          //Signed 32 Bit Min Int
+		{"2147483647", true},           //Signed 32 Bit Max Int
+		{"-2147483649", true},          //Signed 32 Bit Min Int - 1
+		{"2147483648", true},           //Signed 32 Bit Max Int + 1
+		{"4294967295", true},           //Unsigned 32 Bit Max Int
+		{"4294967296", true},           //Unsigned 32 Bit Max Int + 1
 		{"-9223372036854775808", true}, //Signed 64 Bit Min Int
-		{"9223372036854775807", true}, //Signed 64 Bit Max Int
+		{"9223372036854775807", true},  //Signed 64 Bit Max Int
 		{"-9223372036854775809", true}, //Signed 64 Bit Min Int - 1
-		{"9223372036854775808", true}, //Signed 64 Bit Max Int + 1
+		{"9223372036854775808", true},  //Signed 64 Bit Max Int + 1
 		{"18446744073709551615", true}, //Unsigned 64 Bit Max Int
 		{"18446744073709551616", true}, //Unsigned 64 Bit Max Int + 1
 		{"", true},


### PR DESCRIPTION
I tested this against the new tests and it seems to work. +1 and -1 work for both UTFDigit and UTFNumeric.