### PR TITLE
Validation fails on unknown validator

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -583,7 +583,8 @@ func typeCheck(v reflect.Value, t reflect.StructField) (bool, error) {
 				negate = true
 			}
 			if ok := isValidTag(tagOpt); !ok {
-				continue
+				err := fmt.Errorf("Unkown Validator %s", tagOpt)
+				return false, Error{t.Name, err}
 			}
 			if validatefunc, ok := TagMap[tagOpt]; ok {
 				switch v.Kind() {


### PR DESCRIPTION
Problem:

Currently mistypes may lead to successful validation even though right typed a struct wouldn't be valid. 

example:
```go
type FooMistyped struct {
  num string `valid:"requiered"`
}
type Foo struct {
  num string `valid:"required"`
}
```

While ```FooMistyped{}``` would validate to "true" (as no validator with tag *requiered* exists), ```Foo{}``` wouldn't!



