### PR TITLE
Added some extra fields to TestIsURL

### DIFF
--- a/validator_test.go
+++ b/validator_test.go
@@ -598,6 +598,10 @@ func TestIsURL(t *testing.T) {
 		{"irc://#channel@network", true},
 		{"/abs/test/dir", false},
 		{"./rel/test/dir", false},
+		{"http://foo^bar.org", false},
+		{"http://foo&*bar.org", false},
+		{"http://foo&bar.org", false},
+		{"http://foo bar.org", false},
 	}
 	for _, test := range tests {
 		actual := IsURL(test.param)


### PR DESCRIPTION
The fields added to the test are based on values I've seen in URLs in the wild that are not valid. It turns out these extra cases were already handled correctly. 

However, I think that adding the tests makes it explicit that these cases are catered for.