### PR TITLE
Make typeCheck compatible with pointer to non-struct

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -720,13 +720,18 @@ func typeCheck(v reflect.Value, t reflect.StructField) (bool, error) {
 			result = result && resultItem
 		}
 		return result, nil
-
-	case reflect.Interface, reflect.Ptr:
-		// If the value is an interface or pointer then encode its element
+	case reflect.Interface:
+		// If the value is an interface then encode its element
 		if v.IsNil() {
 			return true, nil
 		}
 		return ValidateStruct(v.Interface())
+	case reflect.Ptr:
+		// If the value is a pointer then check its element
+		if v.IsNil() {
+			return true, nil
+		}
+		return typeCheck(v.Elem(), t)
 	case reflect.Struct:
 		return ValidateStruct(v.Interface())
 	default:

--- a/validator_test.go
+++ b/validator_test.go
@@ -1762,7 +1762,7 @@ func TestValidateStructPointers(t *testing.T) {
 		expected string
 	}{
 		{"Name", ""},
-		{"Email", "Email does not validate as email"},
+		{"Email", "invalid does not validate as email"},
 		{"FavoriteFood", ""},
 		{"Nerd", ""},
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -1748,6 +1748,40 @@ func TestErrorByField(t *testing.T) {
 	}
 }
 
+func TestValidateStructPointers(t *testing.T) {
+	// Struct which uses pointers for values
+	type UserWithPointers struct {
+		Name         *string `valid:"-"`
+		Email        *string `valid:"email"`
+		FavoriteFood *string `valid:"length(0|32)"`
+		Nerd         *bool   `valid:"-"`
+	}
+
+	var tests = []struct {
+		param    string
+		expected string
+	}{
+		{"Name", ""},
+		{"Email", "Email does not validate as email"},
+		{"FavoriteFood", ""},
+		{"Nerd", ""},
+	}
+
+	name  := "Herman"
+	email := "invalid"
+	food  := "Pizza"
+	nerd  := true
+	user := &UserWithPointers{&name, &email, &food, &nerd}
+	_, err := ValidateStruct(user)
+
+	for _, test := range tests {
+		actual := ErrorByField(err, test.param)
+		if actual != test.expected {
+			t.Errorf("Expected ErrorByField(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+	}
+}
+
 func ExampleValidateStruct() {
 	type Post struct {
 		Title    string `valid:"alphanum,required"`


### PR DESCRIPTION
`StructValidate` fails to parse structs that contain pointers to non-structs like strings or booleans. The `typeCheck` will call `StructValidate` for all `reflect.Ptr` and `reflect.Interface` values. If A non-struct pointer is passed to `StructValidate` it will return an error (*function only accepts structs; got reflect.Value*) I added a test case for this behaviour and a fix in `typeCheck`. The element from a `reflect.Ptr` value is now passed to `typeCheck` where it is eventually send to `StructValidate` if it is a `reflect.Struct`. Optionally you could do the check without a recursive call to boost performance but that's up to you.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/75)
<!-- Reviewable:end -->
