### PR TITLE
Feature: fail struct validation for undefined validation rules

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -17,7 +17,7 @@ import (
 var fieldsRequiredByDefault bool
 
 // SetFieldsRequiredByDefault causes validation to fail when struct fields
-// do not include validations or are not explicitly marked as exempt (using `valid:"-"`).
+// do not include validations or are not explicitly marked as exempt (using `valid:"-"` or `valid:"email,optional"`).
 // This struct definition will fail govalidator.ValidateStruct() (and the field values do not matter):
 //     type exampleStruct struct {
 //         Name  string ``
@@ -26,6 +26,10 @@ var fieldsRequiredByDefault bool
 //     type exampleStruct2 struct {
 //         Name  string `valid:"-"`
 //         Email string `valid:"email"`
+// Lastly, this will only fail when Email is an invalid email address but not when it's empty:
+//     type exampleStruct2 struct {
+//         Name  string `valid:"-"`
+//         Email string `valid:"email,optional"`
 func SetFieldsRequiredByDefault(value bool) {
 	fieldsRequiredByDefault = value
 }
@@ -596,7 +600,7 @@ func checkRequired(v reflect.Value, t reflect.StructField, options tagOptions) (
 	if options.contains("required") {
 		err := fmt.Errorf("non zero value required")
 		return false, Error{t.Name, err}
-	} else if fieldsRequiredByDefault {
+	} else if fieldsRequiredByDefault && !options.contains("optional") {
 		err := fmt.Errorf("All fields are required to at least have one validation defined")
 		return false, Error{t.Name, err}
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -1681,6 +1681,11 @@ type FieldsRequiredByDefaultButExemptStruct struct {
 	Email string `valid:"email"`
 }
 
+type FieldsRequiredByDefaultButExemptOrOptionalStruct struct {
+	Name  string `valid:"-"`
+	Email string `valid:"optional,email"`
+}
+
 func TestValidateMissingValidationDeclationStruct(t *testing.T) {
 	var tests = []struct {
 		param    MissingValidationDeclationStruct
@@ -1711,6 +1716,30 @@ func TestFieldsRequiredByDefaultButExemptStruct(t *testing.T) {
 		{FieldsRequiredByDefaultButExemptStruct{Name: "TEST"}, false},
 		{FieldsRequiredByDefaultButExemptStruct{Email: ""}, false},
 		{FieldsRequiredByDefaultButExemptStruct{Email: "test@example.com"}, true},
+	}
+	SetFieldsRequiredByDefault(true)
+	for _, test := range tests {
+		actual, err := ValidateStruct(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
+			if err != nil {
+				t.Errorf("Got Error on ValidateStruct(%q): %s", test.param, err)
+			}
+		}
+	}
+	SetFieldsRequiredByDefault(false)
+}
+
+func TestFieldsRequiredByDefaultButExemptOrOptionalStruct(t *testing.T) {
+	var tests = []struct {
+		param    FieldsRequiredByDefaultButExemptOrOptionalStruct
+		expected bool
+	}{
+		{FieldsRequiredByDefaultButExemptOrOptionalStruct{}, true},
+		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Name: "TEST"}, true},
+		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Email: ""}, true},
+		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Email: "test@example.com"}, true},
+		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Email: "test@example"}, false},
 	}
 	SetFieldsRequiredByDefault(true)
 	for _, test := range tests {

--- a/validator_test.go
+++ b/validator_test.go
@@ -1671,6 +1671,60 @@ type Post struct {
 	AuthorIP string `valid:"ipv4"`
 }
 
+type MissingValidationDeclationStruct struct {
+	Name  string ``
+	Email string `valid:"required,email"`
+}
+
+type FieldsRequiredByDefaultButExemptStruct struct {
+	Name  string `valid:"-"`
+	Email string `valid:"email"`
+}
+
+func TestValidateMissingValidationDeclationStruct(t *testing.T) {
+	var tests = []struct {
+		param    MissingValidationDeclationStruct
+		expected bool
+	}{
+		{MissingValidationDeclationStruct{}, false},
+		{MissingValidationDeclationStruct{Name: "TEST", Email: "test@example.com"}, false},
+	}
+	SetFieldsRequiredByDefault(true)
+	for _, test := range tests {
+		actual, err := ValidateStruct(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
+			if err != nil {
+				t.Errorf("Got Error on ValidateStruct(%q): %s", test.param, err)
+			}
+		}
+	}
+	SetFieldsRequiredByDefault(false)
+}
+
+func TestFieldsRequiredByDefaultButExemptStruct(t *testing.T) {
+	var tests = []struct {
+		param    FieldsRequiredByDefaultButExemptStruct
+		expected bool
+	}{
+		{FieldsRequiredByDefaultButExemptStruct{}, false},
+		{FieldsRequiredByDefaultButExemptStruct{Name: "TEST"}, false},
+		{FieldsRequiredByDefaultButExemptStruct{Email: ""}, false},
+		{FieldsRequiredByDefaultButExemptStruct{Email: "test@example.com"}, true},
+	}
+	SetFieldsRequiredByDefault(true)
+	for _, test := range tests {
+		actual, err := ValidateStruct(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
+			if err != nil {
+				t.Errorf("Got Error on ValidateStruct(%q): %s", test.param, err)
+			}
+		}
+	}
+	SetFieldsRequiredByDefault(false)
+}
+
 func TestValidateNegationStruct(t *testing.T) {
 	var tests = []struct {
 		param    NegationStruct


### PR DESCRIPTION
This pull request adds the ability to globally enforce validation rules to be defined for every public struct field. That way, you cannot forget to define a validation rule on a public struct field, even if you mark it as optional (via `valid:"optional,email"`) or as ignored (via `valid:"-"`).

Right now, it's a library-global switch that's activated by calling `govalidator.SetFieldsRequiredByDefault(true)` in an `init()` or even the `main()` function.

I added unit tests and they are all passing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/79)
<!-- Reviewable:end -->
