### PR TITLE
Add ErrorsByField function

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -767,22 +767,33 @@ func isEmptyValue(v reflect.Value) bool {
 }
 
 // ErrorByField returns error for specified field of the struct
-// validated by ValidateStruct or empty string
-// if there are no errors/this field doesn't exists or hasn't errors
+// validated by ValidateStruct or empty string if there are no errors
+// or this field doesn't exists or doesn't have any errors.
 func ErrorByField(e error, field string) string {
 	if e == nil {
 		return ""
+	}
+	return ErrorsByField(e)[field]
+}
+
+// ErrorsByField returns map of errors of the struct validated
+// by ValidateStruct or empty map if there are no errors.
+func ErrorsByField(e error) map[string]string {
+	m := make(map[string]string)
+	if e == nil {
+		return m
 	}
 	// prototype for ValidateStruct
 	errorStr := e.Error()
 	errorList := strings.Split(errorStr, ";")
 	for _, item := range errorList {
-		if strings.HasPrefix(item, field+": ") {
-			item := strings.TrimPrefix(item, field+": ")
-			return item
+		if len(item) == 0 {
+			continue
 		}
+		errorByField := strings.Split(item, ": ")
+		m[errorByField[0]] = errorByField[1]
 	}
-	return ""
+	return m
 }
 
 // Error returns string equivalent for reflect.Type

--- a/validator_test.go
+++ b/validator_test.go
@@ -1878,6 +1878,9 @@ func TestErrorsByField(t *testing.T) {
 	post := &Post{Title: "My123", Message: "duck13126", AuthorIP: "123"}
 	_, err := ValidateStruct(post)
 	errs := ErrorsByField(err)
+	if len(errs) != 2 {
+		t.Errorf("There should only be 2 errors but got %v", len(errs))
+	}
 
 	for _, test := range tests {
 		if actual, ok := errs[test.param]; !ok || actual != test.expected {

--- a/validator_test.go
+++ b/validator_test.go
@@ -1865,6 +1865,27 @@ func TestErrorByField(t *testing.T) {
 	}
 }
 
+func TestErrorsByField(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		param    string
+		expected string
+	}{
+		{"Title", "My123 does not validate as alpha"},
+		{"AuthorIP", "123 does not validate as ipv4"},
+	}
+	post := &Post{Title: "My123", Message: "duck13126", AuthorIP: "123"}
+	_, err := ValidateStruct(post)
+	errs := ErrorsByField(err)
+
+	for _, test := range tests {
+		if actual, ok := errs[test.param]; !ok || actual != test.expected {
+			t.Errorf("Expected ErrorsByField(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+	}
+}
+
 func TestValidateStructPointers(t *testing.T) {
 	// Struct which uses pointers for values
 	type UserWithPointers struct {


### PR DESCRIPTION
The `ErrorsByField(errorsOfStructValidation error)` function returns all errors as a `map[string]string` (key: field name, value: field error message).

Sadly, the only thing that's currently not possible (at least given this implementation) is the nested error hash someone asked for in asaskevich/govalidator#63. I'll try to take a crack at that in the next few days.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/81)
<!-- Reviewable:end -->
