### PR TITLE
Fixed crash for required arrays that are empty

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -747,9 +747,9 @@ func typeCheck(v reflect.Value, t reflect.StructField) (bool, error) {
 
 func isEmptyValue(v reflect.Value) bool {
 	switch v.Kind() {
-	case reflect.String:
+	case reflect.String, reflect.Array:
 		return v.Len() == 0
-	case reflect.Array, reflect.Map, reflect.Slice:
+	case reflect.Map, reflect.Slice:
 		return v.Len() == 0 || v.IsNil()
 	case reflect.Bool:
 		return !v.Bool()

--- a/validator_test.go
+++ b/validator_test.go
@@ -1780,6 +1780,10 @@ func TestValidateStruct(t *testing.T) {
 	}
 }
 
+type testByteArray [8]byte
+type testByteMap map[byte]byte
+type testByteSlice []byte
+
 func TestRequired(t *testing.T) {
 
 	testString := "foobar"
@@ -1828,6 +1832,40 @@ func TestRequired(t *testing.T) {
 				Pointer: &Address{"", "123"},
 			},
 			true,
+		},
+		{
+			struct {
+				TestByteArray testByteArray `valid:"required"`
+			}{},
+			false,
+		},
+		{
+			struct {
+				TestByteArray testByteArray `valid:"required"`
+			}{
+				testByteArray{},
+			},
+			false,
+		},
+		{
+			struct {
+				TestByteArray testByteArray `valid:"required"`
+			}{
+				testByteArray{'1', '2', '3', '4', '5', '6', '7', 'A'},
+			},
+			true,
+		},
+		{
+			struct {
+				TestByteMap testByteMap `valid:"required"`
+			}{},
+			false,
+		},
+		{
+			struct {
+				TestByteSlice testByteSlice `valid:"required"`
+			}{},
+			false,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Fixed making a custom array required crashes due to the fact that an array cannot be checked against `IsNil()`.

The error thrown by the test suite is:
```
panic: reflect: call of reflect.Value.IsNil on array Value [recovered]
	panic: reflect: call of reflect.Value.IsNil on array Value
```

This fixes the crash and adds two more test cases for empty maps and slices as well (they behave correctly).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/82)
<!-- Reviewable:end -->
