### PR TITLE
Correct IsURL

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -52,21 +52,11 @@ func IsURL(str string) bool {
 	if strings.HasPrefix(u.Host, ".") {
 		return false
 	}
-	if u.Scheme != "" {
-		u.Scheme = fmt.Sprintf("%s://", u.Scheme)
+	if u.Host == "" && (u.Path != "" && !strings.Contains(u.Path, ".")) {
+		return false
 	}
-	if u.Host != "" {
-		u.Host = fmt.Sprintf("%s", u.Host)
-	}
-	if u.Path != "" {
-		u.Path = fmt.Sprintf("/%s", u.Path)
-	}
-	if u.RawQuery != "" {
-		u.RawQuery = fmt.Sprintf("?%s", u.RawQuery)
-	}
-	newURL := fmt.Sprintf("%s%s%s%s", u.Scheme, u.Host, u.Path, u.RawQuery)
-	fmt.Println(newURL)
-	return rxURL.MatchString(newURL)
+	return rxURL.MatchString(str)
+
 }
 
 // IsRequestURL check if the string rawurl, assuming

--- a/validator.go
+++ b/validator.go
@@ -52,7 +52,21 @@ func IsURL(str string) bool {
 	if strings.HasPrefix(u.Host, ".") {
 		return false
 	}
-	return rxURL.MatchString(str)
+	if u.Scheme != "" {
+		u.Scheme = fmt.Sprintf("%s://", u.Scheme)
+	}
+	if u.Host != "" {
+		u.Host = fmt.Sprintf("%s", u.Host)
+	}
+	if u.Path != "" {
+		u.Path = fmt.Sprintf("/%s", u.Path)
+	}
+	if u.RawQuery != "" {
+		u.RawQuery = fmt.Sprintf("?%s", u.RawQuery)
+	}
+	newURL := fmt.Sprintf("%s%s%s%s", u.Scheme, u.Host, u.Path, u.RawQuery)
+	fmt.Println(newURL)
+	return rxURL.MatchString(newURL)
 }
 
 // IsRequestURL check if the string rawurl, assuming

--- a/validator_test.go
+++ b/validator_test.go
@@ -618,6 +618,7 @@ func TestIsURL(t *testing.T) {
 		{"http://me.example.com", true},
 		{"http://www.me.example.com", true},
 		{"https://farm6.static.flickr.com", true},
+		{"google", false},
 	}
 	for _, test := range tests {
 		actual := IsURL(test.param)


### PR DESCRIPTION
This fix passes all existing tests cases and the added test for `"google" false`.

The main issue we have to fight against for this is that `url.Parse` only populates `Path` for values like `google` and `foobar.com`. This is the way `url.Parse` is coded and so working with that I've put in some extra checks after the call to `url.Parse` to check some basics on each part of the `url.URL` struct.

It should be clear now and I think we have covered it all.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/84)
<!-- Reviewable:end -->
