### PR TITLE
Add basic custom type validations

### DIFF
--- a/types.go
+++ b/types.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 )
 
-// Validator is a wrapper for validator functions, that returns bool and accepts string.
+// Validator is a wrapper for a validator function that returns bool and accepts string.
 type Validator func(str string) bool
 
 // ParamValidator is a wrapper for validator functions that accepts additional parameters.

--- a/types.go
+++ b/types.go
@@ -8,6 +8,9 @@ import (
 // Validator is a wrapper for a validator function that returns bool and accepts string.
 type Validator func(str string) bool
 
+// CustomTypeValidator is a wrapper for validator functions that returns bool and accepts any type.
+type CustomTypeValidator func(i interface{}) bool
+
 // ParamValidator is a wrapper for validator functions that accepts additional parameters.
 type ParamValidator func(str string, params ...string) bool
 type tagOptions []string
@@ -31,6 +34,11 @@ var ParamTagRegexMap = map[string]*regexp.Regexp{
 	"length":       regexp.MustCompile("^length\\((\\d+)\\|(\\d+)\\)$"),
 	"stringlength": regexp.MustCompile("^stringlength\\((\\d+)\\|(\\d+)\\)$"),
 }
+
+// CustomTypeTagMap is a map of functions that can be used as tags for ValidateStruct function.
+// Use this to validate compound or custom types that need to be handled as a whole, e.g.
+// `type UUID [16]byte` (this would be handled as an array of bytes).
+var CustomTypeTagMap = map[string]CustomTypeValidator{}
 
 // TagMap is a map of functions, that can be used as tags for ValidateStruct function.
 var TagMap = map[string]Validator{

--- a/validator.go
+++ b/validator.go
@@ -672,7 +672,7 @@ func typeCheck(v reflect.Value, t reflect.StructField) (bool, error) {
 							}
 						default:
 							//Not Yet Supported Types (Fail here!)
-							err := fmt.Errorf("Validator %s doesn't supported Kind %s", tagOpt, v.Kind())
+							err := fmt.Errorf("Validator %s doesn't support kind %s", tagOpt, v.Kind())
 							return false, Error{t.Name, err}
 						}
 					}
@@ -694,7 +694,7 @@ func typeCheck(v reflect.Value, t reflect.StructField) (bool, error) {
 					}
 				default:
 					//Not Yet Supported Types (Fail here!)
-					err := fmt.Errorf("Validator %s doesn't supported Kind %s", tagOpt, v.Kind())
+					err := fmt.Errorf("Validator %s doesn't support kind %s for value %v", tagOpt, v.Kind(), v)
 					return false, Error{t.Name, err}
 				}
 			}

--- a/validator.go
+++ b/validator.go
@@ -779,6 +779,8 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Len() == 0
 	case reflect.Map, reflect.Slice:
 		return v.Len() == 0 || v.IsNil()
+	case reflect.Array:
+		return v.Len() == 0
 	case reflect.Bool:
 		return !v.Bool()
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:


### PR DESCRIPTION
This adds basic custom type validations as shown in the tests. I didn't want to leave it in my fork although I'm not 100% happy with it. Additional tag options like `required` or `optional` don't work for custom type validations. As it's implemented right now I can't let additional proceed due to the fact that this would trigger the base type validations as well (i.e. in the unit test I added: `type CustomByteArray [6]byte` which would be validated as an array of `unit8`s as well – that's undesired here).

So, my question is: is this a good first step or would I need to go back to the drawing board? Alas, it doesn't break anything or BC in any way – test suite is still green.

Whatever you decide, you might want to take a look at the panic fix I added in 297a3e5 – you might like to cherry-pick this even if you decide to close the pull request. I can also open another PR just for that if you want.

As always, thanks for an awesome library; it has saved me countless hours of tedious type work. :]

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/91)
<!-- Reviewable:end -->
