### PR TITLE
fix error log when ValidateStruct get invalid arg

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -508,7 +508,7 @@ func ValidateStruct(s interface{}) (bool, error) {
 	}
 	// we only accept structs
 	if val.Kind() != reflect.Struct {
-		return false, fmt.Errorf("function only accepts structs; got %T", val)
+		return false, fmt.Errorf("function only accepts structs; got %s", val.Kind())
 	}
 	var errs Errors
 	for i := 0; i < val.NumField(); i++ {


### PR DESCRIPTION
Right now if ValidateStruct got invalid argument (not a Struct) in always print:

```
function only accepts structs; got reflect.Value
```

Because type of `val` is always `reflect.Value` (https://github.com/asaskevich/govalidator/blob/330d28f27e5daa21b9656342a919a2262b830027/validator.go#L511).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/96)
<!-- Reviewable:end -->
