### PR TITLE
Fixed panic : ErrorsByField crash app

### DIFF
--- a/error.go
+++ b/error.go
@@ -2,6 +2,10 @@ package govalidator
 
 type Errors []error
 
+func (es Errors) Errors() []error {
+	return es
+}
+
 func (es Errors) Error() string {
 	var err string
 	for _, e := range es {

--- a/validator.go
+++ b/validator.go
@@ -830,15 +830,16 @@ func ErrorsByField(e error) map[string]string {
 		return m
 	}
 	// prototype for ValidateStruct
-	errorStr := e.Error()
-	errorList := strings.Split(errorStr, ";")
-	for _, item := range errorList {
-		if len(item) == 0 {
-			continue
+
+	switch e.(type) {
+	case Error:
+		m[e.(Error).Name] = e.(Error).Err.Error()
+	case Errors:
+		for _, item := range e.(Errors).Errors() {
+			m[item.(Error).Name] = item.(Error).Err.Error()
 		}
-		errorByField := strings.Split(item, ": ")
-		m[errorByField[0]] = errorByField[1]
 	}
+
 	return m
 }
 


### PR DESCRIPTION
When ErrorsByField try to parse errors containing semi-colons we get a
panic error : index out of range, so instead of trying to parse string from error we use
plain error

srv_1   | Title: lkdqskjdk does not validate as length(10|300);AdminEmail: qsjd;jdhq does not validate as email;ParticipantEmails: [qlsjdlqk] does not validate as participantEmails;
srv_1   | 2015/11/07 21:59:16 Panic recovery -> runtime error: index out of range
srv_1   | /usr/local/go/src/runtime/panic.go:423 (0x429219)
srv_1   |       gopanic: reflectcall(nil, unsafe.Pointer(d.fn), deferArgs(d), uint32(d.siz), uint32(d.siz))
srv_1   | /usr/local/go/src/runtime/panic.go:12 (0x4276f9)
srv_1   |       panicindex: panic(indexError)
srv_1   | /go/src/github.com/asaskevich/govalidator/validator.go:840 (0x6858e1)
srv_1   |       ErrorsByField: m[errorByField[0]] = errorByField[1]
srv_1   | /go/src/github.com/antham/mkg/srv/api/wishlist.go:67 (0x51279b)
srv_1   |       createWishlist: for name, _ := range(valid.ErrorsByField(err)) {
srv_1   | /go/src/github.com/gin-gonic/gin/context.go:95 (0x5146ca)
srv_1   |       (*Context).Next: c.handlers[c.index](c)
srv_1   | /go/src/github.com/gin-gonic/gin/logger.go:56 (0x525b71)
srv_1   |       LoggerWithWriter.func1: c.Next()
srv_1   | /go/src/github.com/gin-gonic/gin/context.go:95 (0x5146ca)
srv_1   |       (*Context).Next: c.handlers[c.index](c)
srv_1   | /go/src/github.com/gin-gonic/gin/recovery.go:43 (0x5266d1)
srv_1   |       RecoveryWithWriter.func1: c.Next()
srv_1   | /go/src/github.com/gin-gonic/gin/context.go:95 (0x5146ca)
srv_1   |       (*Context).Next: c.handlers[c.index](c)
srv_1   | /go/src/github.com/gin-gonic/gin/gin.go:294 (0x51b122)
srv_1   |       (*Engine).handleHTTPRequest: context.Next()
srv_1   | /go/src/github.com/gin-gonic/gin/gin.go:275 (0x51ad57)
srv_1   |       (*Engine).ServeHTTP: engine.handleHTTPRequest(c)
srv_1   | /usr/local/go/src/net/http/server.go:1862 (0x54506e)
srv_1   |       serverHandler.ServeHTTP: handler.ServeHTTP(rw, req)
srv_1   | /usr/local/go/src/net/http/server.go:1361 (0x5426ae)
srv_1   |       (*conn).serve: serverHandler{c.server}.ServeHTTP(w, w.req)
srv_1   | /usr/local/go/src/runtime/asm_amd64.s:1696 (0x45ac31)
srv_1   |       goexit: BYTE    $0x90   // NOP
srv_1   |

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/97)
<!-- Reviewable:end -->
