### PR TITLE
Fix validation of IPv4-mapped IPv6 addresses

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -458,13 +458,13 @@ func IsIP(str string) bool {
 // IsIPv4 check if the string is an IP version 4.
 func IsIPv4(str string) bool {
 	ip := net.ParseIP(str)
-	return ip != nil && ip.To4() != nil
+	return ip != nil && strings.Contains(str, ".")
 }
 
 // IsIPv6 check if the string is an IP version 6.
 func IsIPv6(str string) bool {
 	ip := net.ParseIP(str)
-	return ip != nil && ip.To4() == nil
+	return ip != nil && strings.Contains(str, ":")
 }
 
 // IsMAC check if a string is valid MAC address.


### PR DESCRIPTION
Hello,

Addresses like ::ffff:c0a8:101 are marked as invalid IPv6 addresses and valid IPv4 addresses :

http://play.golang.org/p/4tNuUR7_yq

This is related to the way addresses are handled in the net/ip package ([16]byte array for both types).

Seems the easiest way to deal with this, is to check if the string is an IP address and, depending on the type, if it contains a dot or a column.

Ref: This [discussion] (http://stackoverflow.com/questions/22751035/golang-distinguish-ipv4-ipv6) on stackoverflow, this [issue] (https://github.com/golang/go/issues/8985) and the [code of ParseIP] (https://golang.org/src/net/ip.go#L638)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/100)
<!-- Reviewable:end -->
