### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ func IsBase64(str string) bool
 func IsByteLength(str string, min, max int) bool
 func IsCreditCard(str string) bool
 func IsDataURI(str string) bool
+func IsDialString(str string) bool
+func IsDNSName(str string) bool
 func IsDivisibleBy(str, num string) bool
 func IsEmail(str string) bool
 func IsFilePath(str string) (bool, int)
@@ -80,6 +82,7 @@ func IsNonNegative(value float64) bool
 func IsNonPositive(value float64) bool
 func IsNull(str string) bool
 func IsNumeric(str string) bool
+func IsPort(str string) bool
 func IsPositive(value float64) bool
 func IsPrintableASCII(str string) bool
 func IsRGBcolor(str string) bool
@@ -188,6 +191,8 @@ Here is a list of available validators for struct fields (validator - used funct
 "base64":         IsBase64,
 "creditcard":     IsCreditCard,
 "datauri":        IsDataURI,
+"dialstring":     IsDialString,
+"dns":            IsDNSName,
 "email":          IsEmail,
 "float":          IsFloat,
 "fullwidth":      IsFullWidth,
@@ -208,6 +213,7 @@ Here is a list of available validators for struct fields (validator - used funct
 "multibyte":      IsMultibyte,
 "null":           IsNull,
 "numeric":        IsNumeric,
+"port":           IsPort,
 "printableascii": IsPrintableASCII,
 "requri":         IsRequestURI,
 "requrl":         IsRequestURL,

--- a/patterns.go
+++ b/patterns.go
@@ -29,6 +29,7 @@ const (
 	DataURI        string = "^data:.+\\/(.+);base64$"
 	Latitude       string = "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$"
 	Longitude      string = "^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
+	DNSName        string = `^([a-zA-Z0-9]{1}[a-zA-Z0-9_-]{1,62}){1}(.[a-zA-Z0-9]{1}[a-zA-Z0-9_-]{1,62})*$`
 	URL            string = `^((ftp|https?):\/\/)?(\S+(:\S*)?@)?((([1-9]\d?|1\d\d|2[01]\d|22[0-3])(\.(1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.([0-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(([a-zA-Z0-9]+([-\.][a-zA-Z0-9]+)*)|((www\.)?))?(([a-z\x{00a1}-\x{ffff}0-9]+-?-?)*[a-z\x{00a1}-\x{ffff}0-9]+)(?:\.([a-z\x{00a1}-\x{ffff}]{2,}))?))(:(\d{1,5}))?((\/|\?|#)[^\s]*)?$`
 	SSN            string = `^\d{3}[- ]?\d{2}[- ]?\d{4}$`
 	WinPath        string = `^[a-zA-Z]:\\(?:[^\\/:*?"<>|\r\n]+\\)*[^\\/:*?"<>|\r\n]*$`
@@ -73,6 +74,7 @@ var (
 	rxDataURI        = regexp.MustCompile(DataURI)
 	rxLatitude       = regexp.MustCompile(Latitude)
 	rxLongitude      = regexp.MustCompile(Longitude)
+	rxDNSName        = regexp.MustCompile(DNSName)
 	rxURL            = regexp.MustCompile(URL)
 	rxSSN            = regexp.MustCompile(SSN)
 	rxWinPath        = regexp.MustCompile(WinPath)

--- a/types.go
+++ b/types.go
@@ -46,6 +46,7 @@ var CustomTypeTagMap = map[string]CustomTypeValidator{}
 var TagMap = map[string]Validator{
 	"email":          IsEmail,
 	"url":            IsURL,
+	"dialstring":     IsDialString,
 	"requrl":         IsRequestURL,
 	"requri":         IsRequestURI,
 	"alpha":          IsAlpha,
@@ -80,8 +81,10 @@ var TagMap = map[string]Validator{
 	"base64":         IsBase64,
 	"datauri":        IsDataURI,
 	"ip":             IsIP,
+	"port":           IsPort,
 	"ipv4":           IsIPv4,
 	"ipv6":           IsIPv6,
+	"dns":            IsDNSName,
 	"mac":            IsMAC,
 	"latitude":       IsLatitude,
 	"longitude":      IsLongitude,

--- a/validator.go
+++ b/validator.go
@@ -9,7 +9,9 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
+
 	"unicode"
 	"unicode/utf8"
 )
@@ -450,9 +452,36 @@ func IsISO3166Alpha3(str string) bool {
 	return false
 }
 
+// IsDNSName will validate the given string as a DNS name
+func IsDNSName(str string) bool {
+	if str == "" || len(strings.Replace(str,".","",-1)) > 255 {
+		// constraints already violated
+		return false
+	}
+	return rxDNSName.MatchString(str)
+}
+
+// IsDialString validates the given string for usage with the various Dial() functions
+func IsDialString(str string) bool {
+
+	if h, p, err := net.SplitHostPort(str); err == nil && h != "" && p != "" && (IsDNSName(h) || IsIP(h)) && IsPort(p) {
+		return true
+	}
+
+	return false
+}
+
 // IsIP checks if a string is either IP version 4 or 6.
 func IsIP(str string) bool {
 	return net.ParseIP(str) != nil
+}
+
+// IsPort checks if a string represents a valid port
+func IsPort(str string) bool {
+	if i, err := strconv.Atoi(str); err == nil && i > 0 && i < 65536 {
+		return true
+	}
+	return false
 }
 
 // IsIPv4 check if the string is an IP version 4.

--- a/validator_test.go
+++ b/validator_test.go
@@ -1443,6 +1443,88 @@ func TestIsIP(t *testing.T) {
 	}
 }
 
+func TestIsPort(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		param    string
+		expected bool
+	}{
+		{"1", true},
+		{"65535", true},
+		{"0", false},
+		{"65536", false},
+		{"65538", false},
+	}
+
+	for _, test := range tests {
+		actual := IsPort(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected IsPort(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+	}
+}
+
+func TestIsDNSName(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		param    string
+		expected bool
+	}{
+		{"localhost", true},
+		{"localhost.local", true},
+		{"localhost.localdomain.intern", true},
+		{"-localhost", false},
+		{"localhost.-localdomain", false},
+		{"localhost.localdomain.-int", false},
+		{"_localhost", false},
+		{"localhost._localdomain", false},
+		{"localhost.localdomain._int", false},
+		{"lÖcalhost", false},
+		{"localhost.lÖcaldomain", false},
+		{"localhost.localdomain.üntern", false},
+		{"漢字汉字", false},
+		{"www.jubfvq1v3p38i51622y0dvmdk1mymowjyeu26gbtw9andgynj1gg8z3msb1kl5z6906k846pj3sulm4kiyk82ln5teqj9nsht59opr0cs5ssltx78lfyvml19lfq1wp4usbl0o36cmiykch1vywbttcus1p9yu0669h8fj4ll7a6bmop505908s1m83q2ec2qr9nbvql2589adma3xsq2o38os2z3dmfh2tth4is4ixyfasasasefqwe4t2ub2fz1rme.de", false},
+	}
+
+	for _, test := range tests {
+		actual := IsDNSName(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected IsDNS(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+	}
+}
+
+func TestIsDialString(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		param    string
+		expected bool
+	}{
+		{"localhost.local:1", true},
+		{"localhost.localdomain:9090", true},
+		{"localhost.localdomain.intern:65535", true},
+		{"127.0.0.1:30000", true},
+		{"[::1]:80", true},
+		{"[1200::AB00:1234::2552:7777:1313]:22",false},
+		{"-localhost:1", false},
+		{"localhost.-localdomain:9090", false},
+		{"localhost.localdomain.-int:65535", false},
+		{"localhost.loc:100000", false},
+		{"漢字汉字:2", false},
+		{"www.jubfvq1v3p38i51622y0dvmdk1mymowjyeu26gbtw9andgynj1gg8z3msb1kl5z6906k846pj3sulm4kiyk82ln5teqj9nsht59opr0cs5ssltx78lfyvml19lfq1wp4usbl0o36cmiykch1vywbttcus1p9yu0669h8fj4ll7a6bmop505908s1m83q2ec2qr9nbvql2589adma3xsq2o38os2z3dmfh2tth4is4ixyfasasasefqwe4t2ub2fz1rme.de:20000", false},
+	}
+
+	for _, test := range tests {
+		actual := IsDialString(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected IsDialString(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+	}
+}
+
 func TestIsMAC(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
I needed a possibility to validate a dial string via a struct tag. Since I thought this could be useful for others, too, I made up a pull request instead of adding the according function to the tagMap locally.

This pull request includes:

 * `IsDialString(str string)` which validates that the string has a host part and a port part, that the host part is either a valid DNS name or a valid IP and that the port is in the valid range.
 * `IsDNSName(str string)` which validates the string to be a valid DNS entry – although TLDs are **not** checked, since `myhost.mydomain.internal` is a perfectly valid DNS entry.
 * `IsPort(str string)` checks wether the string translates to an integer between 1 and 65535.
 * Test methods for the above.
 * Updated documentation

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/108)
<!-- Reviewable:end -->
