### PR TITLE
Fix for issue panic with ErrorsByField #112

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -879,7 +879,16 @@ func ErrorsByField(e error) map[string]string {
 		m[e.(Error).Name] = e.(Error).Err.Error()
 	case Errors:
 		for _, item := range e.(Errors).Errors() {
-			m[item.(Error).Name] = item.(Error).Err.Error()
+			switch item.(type) {
+			case Error:
+				m[item.(Error).Name] = item.(Error).Err.Error()
+			case Errors:
+				for _, item := range e.(Errors).Errors() {
+					for k, v := range ErrorsByField(item) {
+						m[k] = v
+					}
+				}
+			}
 		}
 	}
 

--- a/validator.go
+++ b/validator.go
@@ -879,13 +879,8 @@ func ErrorsByField(e error) map[string]string {
 		m[e.(Error).Name] = e.(Error).Err.Error()
 	case Errors:
 		for _, item := range e.(Errors).Errors() {
-			switch item.(type) {
-			case Error:
-				m[item.(Error).Name] = item.(Error).Err.Error()
-			case Errors:
-				for k, v := range ErrorsByField(item) {
-					m[k] = v
-				}
+			for k, v := range ErrorsByField(item) {
+				m[k] = v
 			}
 		}
 	}

--- a/validator.go
+++ b/validator.go
@@ -883,10 +883,8 @@ func ErrorsByField(e error) map[string]string {
 			case Error:
 				m[item.(Error).Name] = item.(Error).Err.Error()
 			case Errors:
-				for _, item := range e.(Errors).Errors() {
-					for k, v := range ErrorsByField(item) {
-						m[k] = v
-					}
+				for k, v := range ErrorsByField(item) {
+					m[k] = v
 				}
 			}
 		}


### PR DESCRIPTION
When ErrorsByField was called with a error of type Errors the items of Errors wasn't verified.
I changed to verify the item's type. In case of being Error, the new error is added to the map and when is Erros the method ErrorsByField  is called recursively.
With only these change will be possible to override some errors with the same name and also the error message starts to being is a little confuse.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/113)
<!-- Reviewable:end -->
