### PR TITLE
[BC break] Custom validation with context + smaller fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add following line in your `*.go` file:
 ```go
 import "github.com/asaskevich/govalidator"
 ```
-If you unhappy to use long `govalidator`, you can do something like this:
+If you are unhappy to use long `govalidator`, you can do something like this:
 ```go
 import (
   valid "github.com/asaskevich/govalidator"

--- a/arrays.go
+++ b/arrays.go
@@ -18,7 +18,7 @@ func Each(array []interface{}, iterator Iterator) {
 
 // Map iterates over the slice and apply ResultIterator to every item. Returns new slice as a result.
 func Map(array []interface{}, iterator ResultIterator) []interface{} {
-	var result []interface{} = make([]interface{}, len(array))
+	var result = make([]interface{}, len(array))
 	for index, data := range array {
 		result[index] = iterator(data, index)
 	}
@@ -37,7 +37,7 @@ func Find(array []interface{}, iterator ConditionIterator) interface{} {
 
 // Filter iterates over the slice and apply ConditionIterator to every item. Returns new slice.
 func Filter(array []interface{}, iterator ConditionIterator) []interface{} {
-	var result []interface{} = make([]interface{}, 0)
+	var result = make([]interface{}, 0)
 	for index, data := range array {
 		if iterator(data, index) {
 			result = append(result, data)

--- a/arrays_test.go
+++ b/arrays_test.go
@@ -78,7 +78,7 @@ func TestFilter(t *testing.T) {
 		return value.(int)%2 == 0
 	}
 	result := Filter(data, fn)
-	for i, _ := range result {
+	for i := range result {
 		if result[i] != answer[i] {
 			t.Errorf("Expected Filter(..) to be %v, got %v", answer[i], result[i])
 		}

--- a/converter_test.go
+++ b/converter_test.go
@@ -1,6 +1,9 @@
 package govalidator
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestToInt(t *testing.T) {
 	tests := []string{"1000", "-123", "abcdef", "100000000000000000000000000000000000000000000"}
@@ -52,6 +55,24 @@ func TestToFloat(t *testing.T) {
 		if res != expected[i] {
 			t.Log("Case ", i, ": expected ", expected[i], " when result is ", res)
 			t.FailNow()
+		}
+	}
+}
+
+func TestToJSON(t *testing.T) {
+	tests := []interface{}{"test", map[string]string{"a": "b", "b": "c"}, func() error { return fmt.Errorf("Error") }}
+	expected := [][]string{
+		[]string{"\"test\"", "<nil>"},
+		[]string{"{\"a\":\"b\",\"b\":\"c\"}", "<nil>"},
+		[]string{"", "json: unsupported type: func() error"},
+	}
+	for i, test := range tests {
+		actual, err := ToJSON(test)
+		if actual != expected[i][0] {
+			t.Errorf("Expected toJSON(%v) to return '%v', got '%v'", test, expected[i][0], actual)
+		}
+		if fmt.Sprintf("%v", err) != expected[i][1] {
+			t.Errorf("Expected error returned from toJSON(%v) to return '%v', got '%v'", test, expected[i][1], fmt.Sprintf("%v", err))
 		}
 	}
 }

--- a/error.go
+++ b/error.go
@@ -1,7 +1,9 @@
 package govalidator
 
+// Errors is an array of multiple errors and conforms to the error interface.
 type Errors []error
 
+// Errors returns itself.
 func (es Errors) Errors() []error {
 	return es
 }
@@ -14,6 +16,7 @@ func (es Errors) Error() string {
 	return err
 }
 
+// Error encapsulates a name, an error and whether there's a custom error message or not.
 type Error struct {
 	Name                     string
 	Err                      error
@@ -23,7 +26,6 @@ type Error struct {
 func (e Error) Error() string {
 	if e.CustomErrorMessageExists {
 		return e.Err.Error()
-	} else {
-		return e.Name + ": " + e.Err.Error()
 	}
+	return e.Name + ": " + e.Err.Error()
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,29 @@
+package govalidator
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestErrorsToString(t *testing.T) {
+	t.Parallel()
+	customErr := &Error{Name: "Custom Error Name", Err: fmt.Errorf("stdlib error")}
+	customErrWithCustomErrorMessage := &Error{Name: "Custom Error Name 2", Err: fmt.Errorf("Bad stuff happened"), CustomErrorMessageExists: true}
+
+	var tests = []struct {
+		param1   Errors
+		expected string
+	}{
+		{Errors{}, ""},
+		{Errors{fmt.Errorf("Error 1")}, "Error 1;"},
+		{Errors{fmt.Errorf("Error 1"), fmt.Errorf("Error 2")}, "Error 1;Error 2;"},
+		{Errors{customErr, fmt.Errorf("Error 2")}, "Custom Error Name: stdlib error;Error 2;"},
+		{Errors{fmt.Errorf("Error 123"), customErrWithCustomErrorMessage}, "Error 123;Bad stuff happened;"},
+	}
+	for _, test := range tests {
+		actual := test.param1.Error()
+		if actual != test.expected {
+			t.Errorf("Expected Error() to return '%v', got '%v'", test.expected, actual)
+		}
+	}
+}

--- a/numerics_test.go
+++ b/numerics_test.go
@@ -19,7 +19,7 @@ func TestAbs(t *testing.T) {
 	for _, test := range tests {
 		actual := Abs(test.param)
 		if actual != test.expected {
-			t.Errorf("Expected Abs(%q) to be %v, got %v", test.param, test.expected, actual)
+			t.Errorf("Expected Abs(%v) to be %v, got %v", test.param, test.expected, actual)
 		}
 	}
 }
@@ -41,7 +41,7 @@ func TestSign(t *testing.T) {
 	for _, test := range tests {
 		actual := Sign(test.param)
 		if actual != test.expected {
-			t.Errorf("Expected Sign(%q) to be %v, got %v", test.param, test.expected, actual)
+			t.Errorf("Expected Sign(%v) to be %v, got %v", test.param, test.expected, actual)
 		}
 	}
 }
@@ -63,7 +63,7 @@ func TestIsNegative(t *testing.T) {
 	for _, test := range tests {
 		actual := IsNegative(test.param)
 		if actual != test.expected {
-			t.Errorf("Expected IsNegative(%q) to be %v, got %v", test.param, test.expected, actual)
+			t.Errorf("Expected IsNegative(%v) to be %v, got %v", test.param, test.expected, actual)
 		}
 	}
 }
@@ -85,7 +85,7 @@ func TestIsNonNegative(t *testing.T) {
 	for _, test := range tests {
 		actual := IsNonNegative(test.param)
 		if actual != test.expected {
-			t.Errorf("Expected IsNonNegative(%q) to be %v, got %v", test.param, test.expected, actual)
+			t.Errorf("Expected IsNonNegative(%v) to be %v, got %v", test.param, test.expected, actual)
 		}
 	}
 }
@@ -107,7 +107,7 @@ func TestIsPositive(t *testing.T) {
 	for _, test := range tests {
 		actual := IsPositive(test.param)
 		if actual != test.expected {
-			t.Errorf("Expected IsPositive(%q) to be %v, got %v", test.param, test.expected, actual)
+			t.Errorf("Expected IsPositive(%v) to be %v, got %v", test.param, test.expected, actual)
 		}
 	}
 }
@@ -129,7 +129,7 @@ func TestIsNonPositive(t *testing.T) {
 	for _, test := range tests {
 		actual := IsNonPositive(test.param)
 		if actual != test.expected {
-			t.Errorf("Expected IsNonPositive(%q) to be %v, got %v", test.param, test.expected, actual)
+			t.Errorf("Expected IsNonPositive(%v) to be %v, got %v", test.param, test.expected, actual)
 		}
 	}
 }
@@ -151,7 +151,7 @@ func TestIsWhole(t *testing.T) {
 	for _, test := range tests {
 		actual := IsWhole(test.param)
 		if actual != test.expected {
-			t.Errorf("Expected IsWhole(%q) to be %v, got %v", test.param, test.expected, actual)
+			t.Errorf("Expected IsWhole(%v) to be %v, got %v", test.param, test.expected, actual)
 		}
 	}
 }
@@ -173,7 +173,7 @@ func TestIsNatural(t *testing.T) {
 	for _, test := range tests {
 		actual := IsNatural(test.param)
 		if actual != test.expected {
-			t.Errorf("Expected IsNatural(%q) to be %v, got %v", test.param, test.expected, actual)
+			t.Errorf("Expected IsNatural(%v) to be %v, got %v", test.param, test.expected, actual)
 		}
 	}
 }
@@ -198,7 +198,7 @@ func TestInRange(t *testing.T) {
 	for _, test := range tests {
 		actual := InRange(test.param, test.left, test.right)
 		if actual != test.expected {
-			t.Errorf("Expected InRange(%q, %q, %q) to be %v, got %v", test.param, test.left, test.right, test.expected, actual)
+			t.Errorf("Expected InRange(%v, %v, %v) to be %v, got %v", test.param, test.left, test.right, test.expected, actual)
 		}
 	}
 }

--- a/types.go
+++ b/types.go
@@ -9,7 +9,8 @@ import (
 type Validator func(str string) bool
 
 // CustomTypeValidator is a wrapper for validator functions that returns bool and accepts any type.
-type CustomTypeValidator func(i interface{}) bool
+// The second parameter should be the context (in the case of validating a struct: the whole object being validated).
+type CustomTypeValidator func(i interface{}, o interface{}) bool
 
 // ParamValidator is a wrapper for validator functions that accepts additional parameters.
 type ParamValidator func(str string, params ...string) bool

--- a/types.go
+++ b/types.go
@@ -31,6 +31,7 @@ var ParamTagMap = map[string]ParamValidator{
 	"matches":      StringMatches,
 }
 
+// ParamTagRegexMap maps param tags to their respective regexes.
 var ParamTagRegexMap = map[string]*regexp.Regexp{
 	"length":       regexp.MustCompile("^length\\((\\d+)\\|(\\d+)\\)$"),
 	"stringlength": regexp.MustCompile("^stringlength\\((\\d+)\\|(\\d+)\\)$"),

--- a/utils.go
+++ b/utils.go
@@ -189,7 +189,7 @@ func NormalizeEmail(str string) (string, error) {
 	return strings.Join(parts, "@"), nil
 }
 
-// Will truncate a string closest length without breaking words.
+// Truncate a string to the closest length without breaking words.
 func Truncate(str string, length int, ending string) string {
 	var aftstr, befstr string
 	if len(str) > length {
@@ -203,9 +203,8 @@ func Truncate(str string, length int, ending string) string {
 			if present > length && i != 0 {
 				if (length - before) < (present - length) {
 					return Trim(befstr, " /\\.,\"'#!?&@+-") + ending
-				} else {
-					return Trim(aftstr, " /\\.,\"'#!?&@+-") + ending
 				}
+				return Trim(aftstr, " /\\.,\"'#!?&@+-") + ending
 			}
 		}
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -395,6 +395,7 @@ func TestNormalizeEmail(t *testing.T) {
 		{`some.name.midd.lena.me.+extension@googlemail.com`, `somenamemiddlename@gmail.com`},
 		{`some.name+extension@unknown.com`, `some.name+extension@unknown.com`},
 		{`hans@m端ller.com`, `hans@m端ller.com`},
+		{`hans`, ``},
 	}
 	for _, test := range tests {
 		actual, err := NormalizeEmail(test.param)
@@ -416,6 +417,7 @@ func TestTruncate(t *testing.T) {
 		{`Lorem ipsum dolor sit amet, consectetur adipiscing elit.`, 25, `...`, `Lorem ipsum dolor sit amet...`},
 		{`Measuring programming progress by lines of code is like measuring aircraft building progress by weight.`, 35, ` new born babies!`, `Measuring programming progress by new born babies!`},
 		{`Testestestestestestestestestest testestestestestestestestest`, 7, `...`, `Testestestestestestestestestest...`},
+		{`Testing`, 7, `...`, `Testing`},
 	}
 	for _, test := range tests {
 		actual := Truncate(test.param1, test.param2, test.param3)

--- a/validator.go
+++ b/validator.go
@@ -708,7 +708,7 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value) (bool, e
 		if ok := isValidTag(tagOpts[0]); !ok {
 			continue
 		}
-		if validatefunc, ok := CustomTypeTagMap[tagOpts[0]]; ok {
+		if validatefunc, ok := CustomTypeTagMap.Get(tagOpts[0]); ok {
 			customTypeValidatorsExist = true
 			if result := validatefunc(v.Interface(), o.Interface()); !result {
 				if len(tagOpts) == 2 {

--- a/validator.go
+++ b/validator.go
@@ -552,9 +552,9 @@ func ValidateStruct(s interface{}) (bool, error) {
 		if typeField.PkgPath != "" {
 			continue // Private field
 		}
-		resultField, err := typeCheck(valueField, typeField)
-		if err != nil {
-			errs = append(errs, err)
+		resultField, err2 := typeCheck(valueField, typeField, val)
+		if err2 != nil {
+			errs = append(errs, err2)
 		}
 		result = result && resultField
 	}

--- a/validator.go
+++ b/validator.go
@@ -680,7 +680,7 @@ func checkRequired(v reflect.Value, t reflect.StructField, options tagOptions) (
 	return true, nil
 }
 
-func typeCheck(v reflect.Value, t reflect.StructField) (bool, error) {
+func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value) (bool, error) {
 	var customErrorMessageExists bool
 	if !v.IsValid() {
 		return false, nil
@@ -709,7 +709,7 @@ func typeCheck(v reflect.Value, t reflect.StructField) (bool, error) {
 		}
 		if validatefunc, ok := CustomTypeTagMap[tagOptions[0]]; ok {
 			options = append(options[:i], options[i+1:]...) // we found our custom validator, so remove it from the options
-			if result := validatefunc(v.Interface()); !result {
+			if result := validatefunc(v.Interface(), o.Interface()); !result {
 				if len(tagOptions) == 2 {
 					return false, Error{t.Name, fmt.Errorf(tagOptions[1]), true}
 				}
@@ -834,7 +834,7 @@ func typeCheck(v reflect.Value, t reflect.StructField) (bool, error) {
 			var resultItem bool
 			var err error
 			if v.Index(i).Kind() != reflect.Struct {
-				resultItem, err = typeCheck(v.Index(i), t)
+				resultItem, err = typeCheck(v.Index(i), t, o)
 				if err != nil {
 					return false, err
 				}
@@ -853,7 +853,7 @@ func typeCheck(v reflect.Value, t reflect.StructField) (bool, error) {
 			var resultItem bool
 			var err error
 			if v.Index(i).Kind() != reflect.Struct {
-				resultItem, err = typeCheck(v.Index(i), t)
+				resultItem, err = typeCheck(v.Index(i), t, o)
 				if err != nil {
 					return false, err
 				}
@@ -877,7 +877,7 @@ func typeCheck(v reflect.Value, t reflect.StructField) (bool, error) {
 		if v.IsNil() {
 			return true, nil
 		}
-		return typeCheck(v.Elem(), t)
+		return typeCheck(v.Elem(), t, o)
 	case reflect.Struct:
 		return ValidateStruct(v.Interface())
 	default:

--- a/validator_test.go
+++ b/validator_test.go
@@ -1930,7 +1930,18 @@ type StructWithCustomByteArray struct {
 
 func TestStructWithCustomByteArray(t *testing.T) {
 	// add our custom byte array validator that fails when the byte array is pristine (all zeroes)
-	CustomTypeTagMap["customByteArrayValidator"] = CustomTypeValidator(func(i interface{}) bool {
+	CustomTypeTagMap["customByteArrayValidator"] = CustomTypeValidator(func(i interface{}, o interface{}) bool {
+		switch v := o.(type) {
+		case StructWithCustomByteArray:
+			if len(v.Email) > 0 {
+				if v.Email != "test@example.com" {
+					t.Errorf("v.Email should have been 'test@example.com' but was '%s'", v.Email)
+				}
+			}
+		default:
+			t.Errorf("Context object passed to custom validator should have been a StructWithCustomByteArray but was %T (%+v)", o, o)
+		}
+
 		switch v := i.(type) {
 		case CustomByteArray:
 			for _, e := range v { // check if v is empty, i.e. all zeroes

--- a/validator_test.go
+++ b/validator_test.go
@@ -1924,11 +1924,14 @@ func TestFieldsRequiredByDefaultButExemptOrOptionalStruct(t *testing.T) {
 type CustomByteArray [6]byte
 
 type StructWithCustomByteArray struct {
-	ID    CustomByteArray `valid:"customByteArrayValidator"`
-	Email string          `valid:"email"`
+	ID              CustomByteArray `valid:"customByteArrayValidator,customMinLengthValidator"`
+	Email           string          `valid:"email"`
+	CustomMinLength int             `valid:"-"`
 }
 
 func TestStructWithCustomByteArray(t *testing.T) {
+	t.Parallel()
+
 	// add our custom byte array validator that fails when the byte array is pristine (all zeroes)
 	CustomTypeTagMap["customByteArrayValidator"] = CustomTypeValidator(func(i interface{}, o interface{}) bool {
 		switch v := o.(type) {
@@ -1952,6 +1955,13 @@ func TestStructWithCustomByteArray(t *testing.T) {
 		}
 		return false
 	})
+	CustomTypeTagMap["customMinLengthValidator"] = CustomTypeValidator(func(i interface{}, o interface{}) bool {
+		switch v := o.(type) {
+		case StructWithCustomByteArray:
+			return len(v.ID) >= v.CustomMinLength
+		}
+		return false
+	})
 	testCustomByteArray := CustomByteArray{'1', '2', '3', '4', '5', '6'}
 	var tests = []struct {
 		param    StructWithCustomByteArray
@@ -1960,7 +1970,9 @@ func TestStructWithCustomByteArray(t *testing.T) {
 		{StructWithCustomByteArray{}, false},
 		{StructWithCustomByteArray{Email: "test@example.com"}, false},
 		{StructWithCustomByteArray{ID: testCustomByteArray, Email: "test@example.com"}, true},
+		{StructWithCustomByteArray{ID: testCustomByteArray, Email: "test@example.com", CustomMinLength: 7}, false},
 	}
+	SetFieldsRequiredByDefault(true)
 	for _, test := range tests {
 		actual, err := ValidateStruct(test.param)
 		if actual != test.expected {
@@ -1970,6 +1982,7 @@ func TestStructWithCustomByteArray(t *testing.T) {
 			}
 		}
 	}
+	SetFieldsRequiredByDefault(false)
 }
 
 func TestValidateNegationStruct(t *testing.T) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -1933,7 +1933,7 @@ func TestStructWithCustomByteArray(t *testing.T) {
 	t.Parallel()
 
 	// add our custom byte array validator that fails when the byte array is pristine (all zeroes)
-	CustomTypeTagMap["customByteArrayValidator"] = CustomTypeValidator(func(i interface{}, o interface{}) bool {
+	CustomTypeTagMap.Set("customByteArrayValidator", CustomTypeValidator(func(i interface{}, o interface{}) bool {
 		switch v := o.(type) {
 		case StructWithCustomByteArray:
 			if len(v.Email) > 0 {
@@ -1954,14 +1954,14 @@ func TestStructWithCustomByteArray(t *testing.T) {
 			}
 		}
 		return false
-	})
-	CustomTypeTagMap["customMinLengthValidator"] = CustomTypeValidator(func(i interface{}, o interface{}) bool {
+	}))
+	CustomTypeTagMap.Set("customMinLengthValidator", CustomTypeValidator(func(i interface{}, o interface{}) bool {
 		switch v := o.(type) {
 		case StructWithCustomByteArray:
 			return len(v.ID) >= v.CustomMinLength
 		}
 		return false
-	})
+	}))
 	testCustomByteArray := CustomByteArray{'1', '2', '3', '4', '5', '6'}
 	var tests = []struct {
 		param    StructWithCustomByteArray

--- a/validator_test.go
+++ b/validator_test.go
@@ -647,7 +647,7 @@ func TestIsRequestURL(t *testing.T) {
 		expected bool
 	}{
 		{"", false},
-		{"http://foo.bar#com", true},
+		{"http://foo.bar/#com", true},
 		{"http://foobar.com", true},
 		{"https://foobar.com", true},
 		{"foobar.com", false},
@@ -670,7 +670,7 @@ func TestIsRequestURL(t *testing.T) {
 		{"rtmp://foobar.com", true},
 		{"http://www.foo_bar.com/", true},
 		{"http://localhost:3000/", true},
-		{"http://foobar.com#baz=qux", true},
+		{"http://foobar.com/#baz=qux", true},
 		{"http://foobar.com/t$-_.+!*\\'(),", true},
 		{"http://www.foobar.com/~foobar", true},
 		{"http://www.-foobar.com/", true},
@@ -697,7 +697,7 @@ func TestIsRequestURI(t *testing.T) {
 		expected bool
 	}{
 		{"", false},
-		{"http://foo.bar#com", true},
+		{"http://foo.bar/#com", true},
 		{"http://foobar.com", true},
 		{"https://foobar.com", true},
 		{"foobar.com", false},
@@ -719,7 +719,7 @@ func TestIsRequestURI(t *testing.T) {
 		{"rtmp://foobar.com", true},
 		{"http://www.foo_bar.com/", true},
 		{"http://localhost:3000/", true},
-		{"http://foobar.com#baz=qux", true},
+		{"http://foobar.com/#baz=qux", true},
 		{"http://foobar.com/t$-_.+!*\\'(),", true},
 		{"http://www.foobar.com/~foobar", true},
 		{"http://www.-foobar.com/", true},


### PR DESCRIPTION
### Smaller fixes
- fixed various code smells and coding style that the static analyzers found (vet, vetshadow, golint)
- updated test suite errors reported in #118

### Feature enhancement
I enhanced the custom type validators so their validation functions get the object being validated passed as a second argument. It is a BC break but the changes necessary are mechanical in nature (see the updated unit test for an example on how this can be used).

This is not finished yet (working on fixing #116) but I wanted to put this out there in order to ask you about the BC break: is that even an option? I thought about doing it in a backwards-compatible way but that would involve reflection. Variadic parameters aren't an option either. The only other way would be to wrap the value to validate and the object being validated in a custom object. That would make it more future-proof and the custom type validation function signature could be changed so as to not require passing an empty interface. Still, that also breaks BC or worse, breaks all current usages (because the custom validation wrapper object is also an interface{}).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/123)
<!-- Reviewable:end -->
