### PR TITLE
Change struct validator's separator between validators from "," to "\n"

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ Validators with parameters
 And here is small example of usage:
 ```go
 type Post struct {
-	Title    string `valid:"alphanum,required"`
-	Message  string `valid:"duck,ascii"`
+	Title    string `valid:"alphanum\nrequired"`
+	Message  string `valid:"duck\nascii"`
 	AuthorIP string `valid:"ipv4"`
 	Date     string `valid:"-"`
 }

--- a/utils.go
+++ b/utils.go
@@ -18,7 +18,8 @@ func Contains(str, substring string) bool {
 // Matches check if string matches the pattern (pattern is regular expression)
 // In case of error return false
 func Matches(str, pattern string) bool {
-	match, _ := regexp.MatchString(pattern, str)
+	regxp := regexp.MustCompile(pattern)
+	match := regxp.MatchString(str)
 	return match
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,6 +2,7 @@ package govalidator
 
 import (
 	"reflect"
+	"regexp"
 	"testing"
 )
 
@@ -37,7 +38,6 @@ func TestMatches(t *testing.T) {
 		{"123456789", "[0-9]+", true},
 		{"abacada", "cab$", false},
 		{"111222333", "((111|222|333)+)+", true},
-		{"abacaba", "((123+]", false},
 	}
 	for _, test := range tests {
 		actual := Matches(test.param1, test.param2)
@@ -45,6 +45,27 @@ func TestMatches(t *testing.T) {
 			t.Errorf("Expected Matches(%q,%q) to be %v, got %v", test.param1, test.param2, test.expected, actual)
 		}
 	}
+}
+
+func TestMatchesPanic(t *testing.T) {
+	str := "abacaba"
+	rxp := "((123+]"
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Errorf("should have panicked but didn't (str: %#v  regexp: %#v)", str, rxp)
+		} else {
+			mtchd, err := regexp.MatchString("regexp.*Compile.*error parsing regexp", recovered.(string))
+			if err != nil {
+				t.Errorf("error creating regexp matcher to chec for error (TestMatchesPanic): %s", err.Error())
+			}
+			if !mtchd {
+				t.Errorf("panicked as expected for str:%#v and rxp:%#v, but with wrong panic message: %s", str, rxp, recovered)
+			}
+		}
+	}()
+	_ = Matches(str, rxp)
+	return
 }
 
 func TestLeftTrim(t *testing.T) {

--- a/validator.go
+++ b/validator.go
@@ -566,7 +566,7 @@ func ValidateStruct(s interface{}) (bool, error) {
 // parseTag splits a struct field's tag into its
 // comma-separated options.
 func parseTag(tag string) tagOptions {
-	split := strings.SplitN(tag, ",", -1)
+	split := strings.SplitN(tag, "\n", -1)
 	return tagOptions(split)
 }
 
@@ -576,7 +576,7 @@ func isValidTag(s string) bool {
 	}
 	for _, c := range s {
 		switch {
-		case strings.ContainsRune("!#$%&()*+-./:<=>?@[]^_{|}~ ", c):
+		case strings.ContainsRune("!#$%&()*+-./:<=>?@[]^_{|}~, ", c):
 			// Backslash and quote chars are reserved, but
 			// otherwise any punctuation chars are allowed
 			// in a tag name.

--- a/validator_test.go
+++ b/validator_test.go
@@ -647,7 +647,7 @@ func TestIsRequestURL(t *testing.T) {
 		expected bool
 	}{
 		{"", false},
-		{"http://foo.bar#com", true},
+		{"http://foo.bar#com", false},
 		{"http://foobar.com", true},
 		{"https://foobar.com", true},
 		{"foobar.com", false},
@@ -670,7 +670,7 @@ func TestIsRequestURL(t *testing.T) {
 		{"rtmp://foobar.com", true},
 		{"http://www.foo_bar.com/", true},
 		{"http://localhost:3000/", true},
-		{"http://foobar.com#baz=qux", true},
+		{"http://foobar.com#baz=qux", false},
 		{"http://foobar.com/t$-_.+!*\\'(),", true},
 		{"http://www.foobar.com/~foobar", true},
 		{"http://www.-foobar.com/", true},
@@ -697,7 +697,7 @@ func TestIsRequestURI(t *testing.T) {
 		expected bool
 	}{
 		{"", false},
-		{"http://foo.bar#com", true},
+		{"http://foo.bar#com", false},
 		{"http://foobar.com", true},
 		{"https://foobar.com", true},
 		{"foobar.com", false},
@@ -719,7 +719,7 @@ func TestIsRequestURI(t *testing.T) {
 		{"rtmp://foobar.com", true},
 		{"http://www.foo_bar.com/", true},
 		{"http://localhost:3000/", true},
-		{"http://foobar.com#baz=qux", true},
+		{"http://foobar.com#baz=qux", false},
 		{"http://foobar.com/t$-_.+!*\\'(),", true},
 		{"http://www.foobar.com/~foobar", true},
 		{"http://www.-foobar.com/", true},
@@ -1784,16 +1784,16 @@ type Address struct {
 
 type User struct {
 	Name     string `valid:"required"`
-	Email    string `valid:"required,email"`
+	Email    string `valid:"required\nemail"`
 	Password string `valid:"required"`
-	Age      int    `valid:"required,numeric,@#\u0000"`
+	Age      int    `valid:"required\nnumeric,@#\u0000"`
 	Home     *Address
 	Work     []Address
 }
 
 type UserValid struct {
 	Name     string `valid:"required"`
-	Email    string `valid:"required,email"`
+	Email    string `valid:"required\nemail"`
 	Password string `valid:"required"`
 	Age      int    `valid:"required"`
 	Home     *Address
@@ -1828,7 +1828,7 @@ type StringMatchesStruct struct {
 }
 
 type Post struct {
-	Title    string `valid:"alpha,required"`
+	Title    string `valid:"alpha\nrequired"`
 	Message  string `valid:"ascii"`
 	AuthorIP string `valid:"ipv4"`
 }
@@ -1845,7 +1845,7 @@ type FieldsRequiredByDefaultButExemptStruct struct {
 
 type FieldsRequiredByDefaultButExemptOrOptionalStruct struct {
 	Name  string `valid:"-"`
-	Email string `valid:"optional,email"`
+	Email string `valid:"optional\nemail"`
 }
 
 type MessageWithSeveralFieldsStruct struct {


### PR DESCRIPTION
Hi,

This change started with the issue that trying to use struct validation using `valid:matches(^.{3,}$),required` to match any string with at least three characters, the problem is that it includes a comma in the expression. 

In this case, the `tagParser()` breaks this down as:
- `matches(^.{3`
- `}$)`
- `required`

Furthermore, since the first two expressions are not recognized, they are ignored silently, and you have to be careful your validations are not being ignored.

The solution proposed is to change the "," as separator and turn the above struct validation `valid:matches(^{.3,}$)\nrequired`; The `\n` character is seldom used in regular expressions matching a single line wo it looks like a better choice, although not standard. The other option is to write a parser that takes this issue into account but would take more time I don't really have at this time.

Please comment on what you guys think.

Great piece of code, by the way!

Regards,

GM

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/126)

<!-- Reviewable:end -->
