### PR TITLE
Fix: not using custom validator with builtin validator

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -754,6 +754,7 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value) (bool, e
 
 	var customTypeErrors Errors
 	var customTypeValidatorsExist bool
+	var builtinValidatorsExist bool
 	for validatorName, customErrorMessage := range options {
 		if validatefunc, ok := CustomTypeTagMap.Get(validatorName); ok {
 			customTypeValidatorsExist = true
@@ -764,13 +765,17 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value) (bool, e
 				}
 				customTypeErrors = append(customTypeErrors, Error{Name: t.Name, Err: fmt.Errorf("%s does not validate as %s", fmt.Sprint(v), validatorName), CustomErrorMessageExists: false})
 			}
+		} else {
+			builtinValidatorsExist = true
 		}
 	}
 	if customTypeValidatorsExist {
 		if len(customTypeErrors.Errors()) > 0 {
 			return false, customTypeErrors
 		}
-		return true, nil
+		if !builtinValidatorsExist {
+			return true, nil
+		}
 	}
 
 	switch v.Kind() {

--- a/validator_test.go
+++ b/validator_test.go
@@ -2705,3 +2705,30 @@ func TestJSONValidator(t *testing.T) {
 		t.Errorf("Expected error message to contain WithoutJSONName but actual error is: %s", err.Error())
 	}
 }
+
+func TestCustomValidatorWithBuiltinValidator(t *testing.T) {
+
+	CustomTypeTagMap.Set("customvalidator", CustomTypeValidator(func(i interface{}, o interface{}) bool {
+		return true
+	}))
+
+	type Post struct {
+		Title string `valid:"customvalidator,stringlength(5|10)"`
+	}
+
+	post := &Post{"Foo"}
+
+	_, err := ValidateStruct(post)
+
+	if err == nil {
+		t.Error("Expected error but got no error")
+	}
+
+	post2 := &Post{"FooBar"}
+
+	_, err = ValidateStruct(post2)
+
+	if err != nil {
+		t.Errorf("Expected nil but got %v", err)
+	}
+}


### PR DESCRIPTION
At now, I couldn't use custom validators with built-in validators.
If the custom validators return no errors, the validation logic returns true before evaluating built-in validators.

https://github.com/asaskevich/govalidator/blob/872bb01704d183fe276bce6fa429408a87661998/validator.go#L773

Example:

```Go
type Post struct {
    Title string `valid:"customvalidator,stringlength(5|10)"`
}
// The `stringlength(5|10)` is not used.
```

And see [the test code](https://github.com/kohkimakimoto/govalidator/blob/fix-not-using-custom-validator-with-builtin-validator/validator_test.go#L2709-L2734)

This PR fix this problem. Thanks for your useful product!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/189)
<!-- Reviewable:end -->
