### PR TITLE
validator: proper handling of JSON tag options

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -538,6 +538,17 @@ func IsLongitude(str string) bool {
 	return rxLongitude.MatchString(str)
 }
 
+func toJSONName(tag string) string {
+	if tag == "" {
+		return ""
+	}
+
+	// JSON name always comes first. If there's no options then split[0] is
+	// JSON name, if JSON name is not set, then split[0] is an empty string.
+	split := strings.SplitN(tag, ",", 2)
+	return split[0]
+}
+
 // ValidateStruct use tags for fields.
 // result will be equal to `false` if there are any errors.
 func ValidateStruct(s interface{}) (bool, error) {
@@ -565,7 +576,7 @@ func ValidateStruct(s interface{}) (bool, error) {
 		if err2 != nil {
 
 			// Replace structure name with JSON name if there is a tag on the variable
-			jsonTag := typeField.Tag.Get("json")
+			jsonTag := toJSONName(typeField.Tag.Get("json"))
 			if jsonTag != "" {
 				switch jsonError := err2.(type) {
 				case Error:

--- a/validator_test.go
+++ b/validator_test.go
@@ -2741,6 +2741,8 @@ func TestJSONValidator(t *testing.T) {
 	var val struct {
 		WithJSONName    string `json:"with_json_name" valid:"-,required"`
 		WithoutJSONName string `valid:"-,required"`
+		WithJSONOmit    string `json:"with_other_json_name,omitempty" valid:"-,required"`
+		WithJSONOption  string `json:",omitempty" valid:"-,required"`
 	}
 
 	_, err := ValidateStruct(val)
@@ -2755,5 +2757,9 @@ func TestJSONValidator(t *testing.T) {
 
 	if Contains(err.Error(), "WithoutJSONName") == false {
 		t.Errorf("Expected error message to contain WithoutJSONName but actual error is: %s", err.Error())
+	}
+
+	if Contains(err.Error(), "omitempty") {
+		t.Errorf("Expected error message to not contain ',omitempty' but actual error is: %s", err.Error())
 	}
 }


### PR DESCRIPTION
Current JSON tag handling will leak tag options into the error message. For
instance with this type:

```
type Foo struct {
     Foo string `json:"foo,omitempty" valid:"-,required"`
}
```
The error message will contain: 'foo,omitempty: non zero value required;', while
one would expect only 'foo: non zero..'

@asaskevich 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/195)
<!-- Reviewable:end -->
