### PR TITLE
Add ISO4217 support for currency validation

### DIFF
--- a/types.go
+++ b/types.go
@@ -120,6 +120,7 @@ var TagMap = map[string]Validator{
 	"rfc3339":        IsRFC3339,
 	"ISO3166Alpha2":  IsISO3166Alpha2,
 	"ISO3166Alpha3":  IsISO3166Alpha3,
+	"ISO4217":        IsISO4217,
 }
 
 // ISO3166Entry stores country codes
@@ -382,4 +383,33 @@ var ISO3166List = []ISO3166Entry{
 	{"Samoa", "Samoa (le)", "WS", "WSM", "882"},
 	{"Yemen", "Yémen (le)", "YE", "YEM", "887"},
 	{"Zambia", "Zambie (la)", "ZM", "ZMB", "894"},
+}
+
+var ISO4217List = []string{
+	"AED", "AFN", "ALL", "AMD", "ANG", "AOA", "ARS", "AUD", "AWG", "AZN",
+	"BAM", "BBD", "BDT", "BGN", "BHD", "BIF", "BMD", "BND", "BOB", "BOV", "BRL", "BSD", "BTN", "BWP", "BYN", "BZD",
+	"CAD", "CDF", "CHE", "CHF", "CHW", "CLF", "CLP", "CNY", "COP", "COU", "CRC", "CUC", "CUP", "CVE", "CZK",
+	"DJF", "DKK", "DOP", "DZD",
+	"EGP", "ERN", "ETB", "EUR",
+	"FJD", "FKP",
+	"GBP", "GEL", "GHS", "GIP", "GMD", "GNF", "GTQ", "GYD",
+	"HKD", "HNL", "HRK", "HTG", "HUF",
+	"IDR", "ILS", "INR", "IQD", "IRR", "ISK",
+	"JMD", "JOD", "JPY",
+	"KES", "KGS", "KHR", "KMF", "KPW", "KRW", "KWD", "KYD", "KZT",
+	"LAK", "LBP", "LKR", "LRD", "LSL", "LYD",
+	"MAD", "MDL", "MGA", "MKD", "MMK", "MNT", "MOP", "MRO", "MUR", "MVR", "MWK", "MXN", "MXV", "MYR", "MZN",
+	"NAD", "NGN", "NIO", "NOK", "NPR", "NZD",
+	"OMR",
+	"PAB", "PEN", "PGK", "PHP", "PKR", "PLN", "PYG",
+	"QAR",
+	"RON", "RSD", "RUB", "RWF",
+	"SAR", "SBD", "SCR", "SDG", "SEK", "SGD", "SHP", "SLL", "SOS", "SRD", "SSP", "STD", "SVC", "SYP", "SZL",
+	"THB", "TJS", "TMT", "TND", "TOP", "TRY", "TTD", "TWD", "TZS",
+	"UAH", "UGX", "USD", "USN", "UYI", "UYU", "UZS",
+	"VEF", "VND", "VUV",
+	"WST",
+	"XAF", "XAG", "XAU", "XBA", "XBB", "XBC", "XBD", "XCD", "XDR", "XOF", "XPD", "XPF", "XPT", "XSU", "XTS", "XUA", "XXX",
+	"YER",
+	"ZAR", "ZMW", "ZWL",
 }

--- a/validator.go
+++ b/validator.go
@@ -652,6 +652,16 @@ func IsRFC3339(str string) bool {
 	return IsTime(str, time.RFC3339)
 }
 
+func IsISO4217(str string) bool {
+	for _, currency := range ISO4217List {
+		if str == currency {
+			return true
+		}
+	}
+
+	return false
+}
+
 // ByteLength check string's length
 func ByteLength(str string, params ...string) bool {
 	if len(params) == 2 {
@@ -749,8 +759,8 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 	if options == nil {
 		isRootType = true
 		options = parseTagIntoMap(tag)
-  }
-  
+	}
+
 	if isEmptyValue(v) {
 		// an empty value is not validated, check only required
 		return checkRequired(v, t, options)

--- a/validator_test.go
+++ b/validator_test.go
@@ -1619,13 +1619,13 @@ func TestFilePath(t *testing.T) {
 		{"/path/file:SAMPLE/", true, Unix},
 		{"/path/file:/.txt", true, Unix},
 		{"/path", true, Unix},
-    {"/path/__bc/file.txt", true, Unix},
-  	{"/path/a--ac/file.txt", true, Unix},
- 	  {"/_path/file.txt", true, Unix},
- 		{"/path/__bc/file.txt", true, Unix},
- 		{"/path/a--ac/file.txt", true, Unix},
- 		{"/__path/--file.txt", true, Unix},
- 		{"/path/a bc", true, Unix},
+		{"/path/__bc/file.txt", true, Unix},
+		{"/path/a--ac/file.txt", true, Unix},
+		{"/_path/file.txt", true, Unix},
+		{"/path/__bc/file.txt", true, Unix},
+		{"/path/a--ac/file.txt", true, Unix},
+		{"/__path/--file.txt", true, Unix},
+		{"/path/a bc", true, Unix},
 	}
 	for _, test := range tests {
 		actual, osType := IsFilePath(test.param)
@@ -1808,6 +1808,28 @@ func TestIsRFC3339(t *testing.T) {
 	}
 }
 
+func TestIsISO4217(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		param    string
+		expected bool
+	}{
+		{"", false},
+		{"ABCD", false},
+		{"A", false},
+		{"ZZZ", false},
+		{"usd", false},
+		{"USD", true},
+	}
+	for _, test := range tests {
+		actual := IsISO4217(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected IsISO4217(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+	}
+}
+
 func TestByteLength(t *testing.T) {
 	t.Parallel()
 
@@ -1953,6 +1975,7 @@ type StringLengthStruct struct {
 type StringMatchesStruct struct {
 	StringMatches string `valid:"matches(^[0-9]{3}$)"`
 }
+
 // TODO: this testcase should be fixed
 // type StringMatchesComplexStruct struct {
 // 	StringMatches string `valid:"matches(^\\$\\([\"']\\w+[\"']\\)$)"`


### PR DESCRIPTION
This is based on the ISO4217 list of currencies.

See:
- https://www.iso.org/iso-4217-currency-codes.html
- https://www.currency-iso.org/en/home/tables/table-a1.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/196)
<!-- Reviewable:end -->
