### PR TITLE
fixed validator to be able to validate inline structs

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -572,6 +572,14 @@ func ValidateStruct(s interface{}) (bool, error) {
 		if typeField.PkgPath != "" {
 			continue // Private field
 		}
+		structResult := true
+		if valueField.Kind() == reflect.Struct {
+			var err error
+			structResult, err = ValidateStruct(valueField.Interface())
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
 		resultField, err2 := typeCheck(valueField, typeField, val, nil)
 		if err2 != nil {
 
@@ -596,7 +604,7 @@ func ValidateStruct(s interface{}) (bool, error) {
 
 			errs = append(errs, err2)
 		}
-		result = result && resultField
+		result = result && resultField && structResult
 	}
 	if len(errs) > 0 {
 		err = errs


### PR DESCRIPTION
Feel free to merge if you want, usage example:

```
type User struct {
	EmailField     `bson:",inline"`
	LastLoginDate  time.Time     `json:"lastLoginDate" bson:"lastLoginDate"`
	OrganizationId bson.ObjectId `json:"organizationId" bson:"organizationId" valid:"required"`
	ProfileFields  `bson:",inline"`
}

type UserWithPassword struct {
	User          `bson:",inline"`
	PasswordField `bson:",inline"`
}

type ProfileFields struct {
	FirstName string `json:"firstName" bson:"firstName"`
	LastName  string `json:"lastName" bson:"lastName"`
	Phone     string `json:"phone"`
	AvatarUrl string `json:"avatarUrl" bson:"avatarUrl"`
}

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/201)
<!-- Reviewable:end -->
