### PR TITLE
Do not validate nested structs when explicitly ignored

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -595,7 +595,7 @@ func ValidateStruct(s interface{}) (bool, error) {
 			continue // Private field
 		}
 		structResult := true
-		if valueField.Kind() == reflect.Struct {
+		if valueField.Kind() == reflect.Struct && typeField.Tag.Get(tagName) != "-" {
 			var err error
 			structResult, err = ValidateStruct(valueField.Interface())
 			if err != nil {


### PR DESCRIPTION
When validating structs with nested structs like this:
```go
type Comment struct {
    Text   string `valid:"required"`
    Author User   `valid:"-"`
}
```
I do not want to validate `User` for each `Comment` so having an option to explicitly ignore it is nice. I think this would be expected behavior in such a case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/217)
<!-- Reviewable:end -->
