### PR TITLE
Use strings.Join to join error strings

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,5 +1,7 @@
 package govalidator
 
+import "strings"
+
 // Errors is an array of multiple errors and conforms to the error interface.
 type Errors []error
 
@@ -9,11 +11,11 @@ func (es Errors) Errors() []error {
 }
 
 func (es Errors) Error() string {
-	var err string
+	var errs []string
 	for _, e := range es {
-		err += e.Error() + ";"
+		errs = append(errs, e.Error())
 	}
-	return err
+	return strings.Join(errs, ";")
 }
 
 // Error encapsulates a name, an error and whether there's a custom error message or not.

--- a/error_test.go
+++ b/error_test.go
@@ -15,10 +15,10 @@ func TestErrorsToString(t *testing.T) {
 		expected string
 	}{
 		{Errors{}, ""},
-		{Errors{fmt.Errorf("Error 1")}, "Error 1;"},
-		{Errors{fmt.Errorf("Error 1"), fmt.Errorf("Error 2")}, "Error 1;Error 2;"},
-		{Errors{customErr, fmt.Errorf("Error 2")}, "Custom Error Name: stdlib error;Error 2;"},
-		{Errors{fmt.Errorf("Error 123"), customErrWithCustomErrorMessage}, "Error 123;Bad stuff happened;"},
+		{Errors{fmt.Errorf("Error 1")}, "Error 1"},
+		{Errors{fmt.Errorf("Error 1"), fmt.Errorf("Error 2")}, "Error 1;Error 2"},
+		{Errors{customErr, fmt.Errorf("Error 2")}, "Custom Error Name: stdlib error;Error 2"},
+		{Errors{fmt.Errorf("Error 123"), customErrWithCustomErrorMessage}, "Error 123;Bad stuff happened"},
 	}
 	for _, test := range tests {
 		actual := test.param1.Error()


### PR DESCRIPTION
Makes it easier to split the string

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/227)
<!-- Reviewable:end -->
