### PR TITLE
Fix array validation

### DIFF
--- a/validator_test.go
+++ b/validator_test.go
@@ -2495,6 +2495,7 @@ func TestValidateStruct(t *testing.T) {
 		{UserValid{"John", "", "12345", 0, &Address{"Street", "123456789"}, []Address{{"Street", "ABC456D89"}, {"Street", "123456"}}}, false},
 		{nil, true},
 		{User{"John", "john@yahoo.com", "123G#678", 0, &Address{"Street", "123456"}, []Address{}}, false},
+		{PrivateStruct{"d_k", 0, []int{1, 2}, []string{"hi", "super2"}, [2]Address{}, Address{"Street", "123456"}, nil}, false},
 		{"im not a struct", false},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
There was a problem validating elements of array discussed in #197 

I tested it and found out that array validation was only checking the first element. 

In this case;
```golang
type Example struct { IPs []stringvalid:"ipv4" json:"ip"} 
```
This is valid;
```json
{"ip":["1.1.1.1","1.1.1.2"]}
```
This is valid;
```json
{"ip":["1.1.1.1","1.1.1.asdad"]}
```
This is not valid;
```json
{"ip":["1.1.1.asda","1.1.1.2"]}
```
This is because, after checking the first it element the option was removed. Since maps are passed by reference, in the [next iteration](../blob/master/validator.go#L954) there was not a validation option to check. 
 
So I added `usedOptions` parameter to store valid and used options then compare to `options` in the defered function to find invalid options.
