### PR TITLE
Expose the Validator that Failed in the Error

### DIFF
--- a/error.go
+++ b/error.go
@@ -23,6 +23,9 @@ type Error struct {
 	Name                     string
 	Err                      error
 	CustomErrorMessageExists bool
+
+	// Validator indicates the name of the validator that failed
+	Validator string
 }
 
 func (e Error) Error() string {

--- a/validator.go
+++ b/validator.go
@@ -20,6 +20,7 @@ var (
 	fieldsRequiredByDefault bool
 	notNumberRegexp         = regexp.MustCompile("[^0-9]+")
 	whiteSpacesAndMinus     = regexp.MustCompile("[\\s-]+")
+	paramsRegexp            = regexp.MustCompile("\\(.*\\)$")
 )
 
 const maxURLRuneCount = 2083
@@ -776,11 +777,11 @@ func IsIn(str string, params ...string) bool {
 func checkRequired(v reflect.Value, t reflect.StructField, options tagOptionsMap) (bool, error) {
 	if requiredOption, isRequired := options["required"]; isRequired {
 		if len(requiredOption) > 0 {
-			return false, Error{t.Name, fmt.Errorf(requiredOption), true}
+			return false, Error{t.Name, fmt.Errorf(requiredOption), true, "required"}
 		}
-		return false, Error{t.Name, fmt.Errorf("non zero value required"), false}
+		return false, Error{t.Name, fmt.Errorf("non zero value required"), false, "required"}
 	} else if _, isOptional := options["optional"]; fieldsRequiredByDefault && !isOptional {
-		return false, Error{t.Name, fmt.Errorf("All fields are required to at least have one validation defined"), false}
+		return false, Error{t.Name, fmt.Errorf("All fields are required to at least have one validation defined"), false, "required"}
 	}
 	// not required and empty is valid
 	return true, nil
@@ -799,7 +800,7 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 		if !fieldsRequiredByDefault {
 			return true, nil
 		}
-		return false, Error{t.Name, fmt.Errorf("All fields are required to at least have one validation defined"), false}
+		return false, Error{t.Name, fmt.Errorf("All fields are required to at least have one validation defined"), false, "required"}
 	case "-":
 		return true, nil
 	}
@@ -822,10 +823,10 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 
 			if result := validatefunc(v.Interface(), o.Interface()); !result {
 				if len(customErrorMessage) > 0 {
-					customTypeErrors = append(customTypeErrors, Error{Name: t.Name, Err: fmt.Errorf(customErrorMessage), CustomErrorMessageExists: true})
+					customTypeErrors = append(customTypeErrors, Error{Name: t.Name, Err: fmt.Errorf(customErrorMessage), CustomErrorMessageExists: true, Validator: stripParams(validatorName)})
 					continue
 				}
-				customTypeErrors = append(customTypeErrors, Error{Name: t.Name, Err: fmt.Errorf("%s does not validate as %s", fmt.Sprint(v), validatorName), CustomErrorMessageExists: false})
+				customTypeErrors = append(customTypeErrors, Error{Name: t.Name, Err: fmt.Errorf("%s does not validate as %s", fmt.Sprint(v), validatorName), CustomErrorMessageExists: false, Validator: stripParams(validatorName)})
 			}
 		}
 	}
@@ -844,7 +845,7 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 				for validator := range options {
 					isValid = false
 					resultErr = Error{t.Name, fmt.Errorf(
-						"The following validator is invalid or can't be applied to the field: %q", validator), false}
+						"The following validator is invalid or can't be applied to the field: %q", validator), false, stripParams(validator)}
 					return
 				}
 			}
@@ -888,16 +889,16 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 					field := fmt.Sprint(v) // make value into string, then validate with regex
 					if result := validatefunc(field, ps[1:]...); (!result && !negate) || (result && negate) {
 						if customMsgExists {
-							return false, Error{t.Name, fmt.Errorf(customErrorMessage), customMsgExists}
+							return false, Error{t.Name, fmt.Errorf(customErrorMessage), customMsgExists, stripParams(validatorSpec)}
 						}
 						if negate {
-							return false, Error{t.Name, fmt.Errorf("%s does validate as %s", field, validator), customMsgExists}
+							return false, Error{t.Name, fmt.Errorf("%s does validate as %s", field, validator), customMsgExists, stripParams(validatorSpec)}
 						}
-						return false, Error{t.Name, fmt.Errorf("%s does not validate as %s", field, validator), customMsgExists}
+						return false, Error{t.Name, fmt.Errorf("%s does not validate as %s", field, validator), customMsgExists, stripParams(validatorSpec)}
 					}
 				default:
 					// type not yet supported, fail
-					return false, Error{t.Name, fmt.Errorf("Validator %s doesn't support kind %s", validator, v.Kind()), false}
+					return false, Error{t.Name, fmt.Errorf("Validator %s doesn't support kind %s", validator, v.Kind()), false, stripParams(validatorSpec)}
 				}
 			}
 
@@ -909,17 +910,17 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 					field := fmt.Sprint(v) // make value into string, then validate with regex
 					if result := validatefunc(field); !result && !negate || result && negate {
 						if customMsgExists {
-							return false, Error{t.Name, fmt.Errorf(customErrorMessage), customMsgExists}
+							return false, Error{t.Name, fmt.Errorf(customErrorMessage), customMsgExists, stripParams(validatorSpec)}
 						}
 						if negate {
-							return false, Error{t.Name, fmt.Errorf("%s does validate as %s", field, validator), customMsgExists}
+							return false, Error{t.Name, fmt.Errorf("%s does validate as %s", field, validator), customMsgExists, stripParams(validatorSpec)}
 						}
-						return false, Error{t.Name, fmt.Errorf("%s does not validate as %s", field, validator), customMsgExists}
+						return false, Error{t.Name, fmt.Errorf("%s does not validate as %s", field, validator), customMsgExists, stripParams(validatorSpec)}
 					}
 				default:
 					//Not Yet Supported Types (Fail here!)
 					err := fmt.Errorf("Validator %s doesn't support kind %s for value %v", validator, v.Kind(), v)
-					return false, Error{t.Name, err, false}
+					return false, Error{t.Name, err, false, stripParams(validatorSpec)}
 				}
 			}
 		}
@@ -985,6 +986,10 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 	default:
 		return false, &UnsupportedTypeError{v.Type()}
 	}
+}
+
+func stripParams(validatorString string) string {
+	return paramsRegexp.ReplaceAllString(validatorString, "")
 }
 
 func isEmptyValue(v reflect.Value) bool {

--- a/validator_test.go
+++ b/validator_test.go
@@ -2162,7 +2162,7 @@ func TestInvalidValidator(t *testing.T) {
 
 	invalidStruct := InvalidStruct{1}
 	if valid, err := ValidateStruct(&invalidStruct); valid || err == nil ||
-		err.Error() != `Field: The following validator is invalid or can't be applied to the field: "someInvalidValidator";` {
+		err.Error() != `Field: The following validator is invalid or can't be applied to the field: "someInvalidValidator"` {
 		t.Errorf("Got an unexpected result for struct with invalid validator: %t %s", valid, err)
 	}
 }
@@ -2184,12 +2184,12 @@ func TestCustomValidator(t *testing.T) {
 		t.Errorf("Got an unexpected result for struct with custom always true validator: %t %s", valid, err)
 	}
 
-	if valid, err := ValidateStruct(&InvalidStruct{Field: 1}); valid || err == nil || err.Error() != "Custom validator error;;" {
+	if valid, err := ValidateStruct(&InvalidStruct{Field: 1}); valid || err == nil || err.Error() != "Custom validator error" {
 		t.Errorf("Got an unexpected result for struct with custom always false validator: %t %s", valid, err)
 	}
 
 	mixedStruct := StructWithCustomAndBuiltinValidator{}
-	if valid, err := ValidateStruct(&mixedStruct); valid || err == nil || err.Error() != "Field: non zero value required;" {
+	if valid, err := ValidateStruct(&mixedStruct); valid || err == nil || err.Error() != "Field: non zero value required" {
 		t.Errorf("Got an unexpected result for invalid struct with custom and built-in validators: %t %s", valid, err)
 	}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -2711,7 +2711,7 @@ func TestErrorsByField(t *testing.T) {
 		{"CustomField", "An error occurred"},
 	}
 
-	err = Error{"CustomField", fmt.Errorf("An error occurred"), false}
+	err = Error{"CustomField", fmt.Errorf("An error occurred"), false, "hello"}
 	errs = ErrorsByField(err)
 
 	if len(errs) != 1 {
@@ -2879,4 +2879,71 @@ func TestJSONValidator(t *testing.T) {
 	if Contains(err.Error(), "omitempty") {
 		t.Errorf("Expected error message to not contain ',omitempty' but actual error is: %s", err.Error())
 	}
+}
+
+func TestValidatorIncludedInError(t *testing.T) {
+	post := Post{
+		Title:    "",
+		Message:  "👍",
+		AuthorIP: "xyz",
+	}
+
+	validatorMap := map[string]string{
+		"Title":    "required",
+		"Message":  "ascii",
+		"AuthorIP": "ipv4",
+	}
+
+	ok, errors := ValidateStruct(post)
+	if ok {
+		t.Errorf("expected validation to fail %v", ok)
+	}
+
+	for _, e := range errors.(Errors) {
+		casted := e.(Error)
+		if validatorMap[casted.Name] != casted.Validator {
+			t.Errorf("expected validator for %s to be %s, but was %s", casted.Name, validatorMap[casted.Name], casted.Validator)
+		}
+	}
+
+	// check to make sure that validators with arguments (like length(1|10)) don't include the arguments
+	// in the validator name
+	message := MessageWithSeveralFieldsStruct{
+		Title: "",
+		Body:  "asdfasdfasdfasdfasdf",
+	}
+
+	validatorMap = map[string]string{
+		"Title": "length",
+		"Body":  "length",
+	}
+
+	ok, errors = ValidateStruct(message)
+	if ok {
+		t.Errorf("expected validation to fail, %v", ok)
+	}
+
+	for _, e := range errors.(Errors) {
+		casted := e.(Error)
+		if validatorMap[casted.Name] != casted.Validator {
+			t.Errorf("expected validator for %s to be %s, but was %s", casted.Name, validatorMap[casted.Name], casted.Validator)
+		}
+	}
+
+	// make sure validators with custom messages don't show up in the validator string
+	type CustomMessage struct {
+		Text string `valid:"length(1|10)~Custom message"`
+	}
+	cs := CustomMessage{Text: "asdfasdfasdfasdf"}
+
+	ok, errors = ValidateStruct(&cs)
+	if ok {
+		t.Errorf("expected validation to fail, %v", ok)
+	}
+
+	validator := errors.(Errors)[0].(Error).Validator
+	if validator != "length" {
+		t.Errorf("expected validator for Text to be length, but was %s", validator)
+	}
+
 }


### PR DESCRIPTION
In some cases it is convenient to have access to the validator that failed
the validation in the error response.  This fix exposes the validator that was
used in the error so it can be used downstream.

My case has it returned in a JSON response so that errors can be shown in a
user interface more conveniently.  Given a struct defined as follows:

```go
type Page struct {
	Address string `db:"address" json:"address" default:"" valid:"url"`
}
```
... that uses the built-in url validation, I'd like to be able to create a response as follows:

```json
{
  "error": {
    "code": "validation",
    "message": "Field validation failed",
    "details": {
      "address": {
        "code": "url",
        "key": "pageAddress",
        "message": "name: non-url does not validate as url"
      }
    }
  }
}
```

This commit allows the `"code": "url"` part to be available to the error handler.

Separately, I fixed a few tests that were broken based on some possibly old text matching...

Comments/suggestions welcome!

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/229)
<!-- Reviewable:end -->
