### PR TITLE
validator: proper handling of JSON fields with ignore tag

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -569,7 +569,16 @@ func toJSONName(tag string) string {
 	// JSON name always comes first. If there's no options then split[0] is
 	// JSON name, if JSON name is not set, then split[0] is an empty string.
 	split := strings.SplitN(tag, ",", 2)
-	return split[0]
+
+	name := split[0]
+
+	// However it is possible that the field is skipped when
+	// (de-)serializing from/to JSON, in which case assume that there is no
+	// tag name to use
+	if name == "-" {
+		return ""
+	}
+	return name
 }
 
 // ValidateStruct use tags for fields.

--- a/validator_test.go
+++ b/validator_test.go
@@ -2856,10 +2856,11 @@ func TestOptionalCustomValidators(t *testing.T) {
 func TestJSONValidator(t *testing.T) {
 
 	var val struct {
-		WithJSONName    string `json:"with_json_name" valid:"-,required"`
-		WithoutJSONName string `valid:"-,required"`
-		WithJSONOmit    string `json:"with_other_json_name,omitempty" valid:"-,required"`
-		WithJSONOption  string `json:",omitempty" valid:"-,required"`
+		WithJSONName      string `json:"with_json_name" valid:"-,required"`
+		WithoutJSONName   string `valid:"-,required"`
+		WithJSONOmit      string `json:"with_other_json_name,omitempty" valid:"-,required"`
+		WithJSONOption    string `json:",omitempty" valid:"-,required"`
+		WithEmptyJSONName string `json:"-" valid:"-,required"`
 	}
 
 	_, err := ValidateStruct(val)
@@ -2878,6 +2879,10 @@ func TestJSONValidator(t *testing.T) {
 
 	if Contains(err.Error(), "omitempty") {
 		t.Errorf("Expected error message to not contain ',omitempty' but actual error is: %s", err.Error())
+	}
+
+	if !Contains(err.Error(), "WithEmptyJSONName") {
+		t.Errorf("Expected error message to contain WithEmptyJSONName but actual error is: %s", err.Error())
 	}
 }
 


### PR DESCRIPTION
The validator code will correctly use JSON field names if those are defined for
given type. However, it is possible to set JSON tags with "-" ignore setting in
order to prevent the field from being (de-)serialized to/from JSON. In this
case, the validation error message contain '-' as field name (as it was defined
in JSON tag) instead of the struct field name.

Take this type as an example:

```
type Foo struct {
     Foo string `json:"-" valid:"-,required"`
}
```

The error message will contain: `-: non zero value required`, while one would
expect `Foo: non zero..`

@asaskevich minor fix for JSON tag names

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/233)
<!-- Reviewable:end -->
