### PR TITLE
Don't append underscore characters when converting a string to camelCase

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -108,7 +108,7 @@ func CamelCaseToUnderscore(str string) string {
 	var output []rune
 	var segment []rune
 	for _, r := range str {
-		if !unicode.IsLower(r) {
+		if !unicode.IsLower(r) && string(r) != "_" {
 			output = addSegment(output, segment)
 			segment = nil
 		}

--- a/utils_test.go
+++ b/utils_test.go
@@ -269,6 +269,7 @@ func TestCamelCaseToUnderscore(t *testing.T) {
 		{"MyFunc", "my_func"},
 		{"ABC", "a_b_c"},
 		{"1B", "1_b"},
+		{"foo_bar", "foo_bar"},
 	}
 	for _, test := range tests {
 		actual := CamelCaseToUnderscore(test.param)


### PR DESCRIPTION
When running CamelCaseToUnderscore(str), if the string contained an
underscore character, that underscore character would appear twice in
the final string. For Example: my_func => my__func

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/235)
<!-- Reviewable:end -->
