### PR TITLE
Add json name to Errors 

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -614,6 +614,14 @@ func ValidateStruct(s interface{}) (bool, error) {
 					jsonError.Name = jsonTag
 					err2 = jsonError
 				case Errors:
+					for i2, err3 := range jsonError {
+						switch customErr := err3.(type) {
+						case Error:
+							customErr.Name = jsonTag
+							jsonError[i2] = customErr
+						}
+					}
+
 					err2 = jsonError
 				}
 			}


### PR DESCRIPTION
We currently have a weird behaviour if we have basic and custom validators on a field with a JSON tag. 

If a custom validator fails the name inside the `govalidator.Error` will be the name of the field won't be the JSON tag one but if it's a default validator it will be the JSON tag one.

Eg: 

```
func init() {
	valid.CustomTypeTagMap.Set("dummy-validator", valid.CustomTypeValidator(func(i interface{}, o interface{}) bool {
		switch v := i.(type) {
		case float64:
			return v > 10
		default:
			return false
		}
	}))
}

type DummyPayload struct {
	DummyValue  float64 `json:"dummy_value" valid:"required,dummy-validator,url"`
}

```

```
v := DummyPayload{DummyValue: 5}
ok ,err := valid.ValidateStruct(v)
```

The `govalidator.Error.Name` inside the `govalidator.Errors` will be `DummyValue` 

```
v := DummyPayload{DummyValue: 15}
ok ,err := valid.ValidateStruct(v)
```

And here the `Name` will be `dummy_value`

It creates inconsistency when rendering the error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/237)
<!-- Reviewable:end -->
