### PR TITLE
Issue #233 - Added InRangeInt, InRangeFloat32, InRange64 & modified InRange

### DIFF
--- a/numerics.go
+++ b/numerics.go
@@ -1,6 +1,9 @@
 package govalidator
 
-import "math"
+import (
+	"math"
+	"reflect"
+)
 
 // Abs returns absolute value of number
 func Abs(value float64) float64 {
@@ -39,11 +42,45 @@ func IsNonPositive(value float64) bool {
 }
 
 // InRange returns true if value lies between left and right border
-func InRange(value, left, right float64) bool {
+func InRangeInt(value, left, right int) bool {
 	if left > right {
 		left, right = right, left
 	}
 	return value >= left && value <= right
+}
+
+// InRange returns true if value lies between left and right border
+func InRangeFloat32(value, left, right float32) bool {
+	if left > right {
+		left, right = right, left
+	}
+	return value >= left && value <= right
+}
+
+// InRange returns true if value lies between left and right border
+func InRangeFloat64(value, left, right float64) bool {
+	if left > right {
+		left, right = right, left
+	}
+	return value >= left && value <= right
+}
+
+// InRange returns true if value lies between left and right border, generic type to handle int, float32 or float64, all types must the same type
+func InRange(value interface{}, left interface{}, right interface{}) bool {
+
+	reflectValue := reflect.TypeOf(value).Kind()
+	reflectLeft := reflect.TypeOf(left).Kind()
+	reflectRight := reflect.TypeOf(right).Kind()
+
+	if reflectValue == reflect.Int && reflectLeft == reflect.Int && reflectRight == reflect.Int {
+		return InRangeInt(value.(int), left.(int), right.(int))
+	} else if reflectValue == reflect.Float32 && reflectLeft == reflect.Float32 && reflectRight == reflect.Float32 {
+		return InRangeFloat32(value.(float32), left.(float32), right.(float32))
+	} else if reflectValue == reflect.Float64 && reflectLeft == reflect.Float64 && reflectRight == reflect.Float64 {
+		return InRangeFloat64(value.(float64), left.(float64), right.(float64))
+	} else {
+		return false
+	}
 }
 
 // IsWhole returns true if value is whole number

--- a/numerics_test.go
+++ b/numerics_test.go
@@ -177,7 +177,60 @@ func TestIsNatural(t *testing.T) {
 		}
 	}
 }
-func TestInRange(t *testing.T) {
+
+func TestInRangeInt(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		param    int
+		left     int
+		right    int
+		expected bool
+	}{
+		{0, 0, 0, true},
+		{1, 0, 0, false},
+		{-1, 0, 0, false},
+		{0, -1, 1, true},
+		{0, 0, 1, true},
+		{0, -1, 0, true},
+		{0, 0, -1, true},
+		{0, 10, 5, false},
+	}
+	for _, test := range tests {
+		actual := InRangeInt(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRangeInt(%v, %v, %v) to be %v, got %v", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+}
+
+func TestInRangeFloat32(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		param    float32
+		left     float32
+		right    float32
+		expected bool
+	}{
+		{0, 0, 0, true},
+		{1, 0, 0, false},
+		{-1, 0, 0, false},
+		{0, -1, 1, true},
+		{0, 0, 1, true},
+		{0, -1, 0, true},
+		{0, 0, -1, true},
+		{0, 10, 5, false},
+	}
+	for _, test := range tests {
+		actual := InRangeFloat32(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRangeFloat32(%v, %v, %v) to be %v, got %v", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+}
+
+func TestInRangeFloat64(t *testing.T) {
 	t.Parallel()
 
 	var tests = []struct {
@@ -196,6 +249,98 @@ func TestInRange(t *testing.T) {
 		{0, 10, 5, false},
 	}
 	for _, test := range tests {
+		actual := InRangeFloat64(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRangeFloat64(%v, %v, %v) to be %v, got %v", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+}
+
+func TestInRange(t *testing.T) {
+	t.Parallel()
+
+	var testsInt = []struct {
+		param    int
+		left     int
+		right    int
+		expected bool
+	}{
+		{0, 0, 0, true},
+		{1, 0, 0, false},
+		{-1, 0, 0, false},
+		{0, -1, 1, true},
+		{0, 0, 1, true},
+		{0, -1, 0, true},
+		{0, 0, -1, true},
+		{0, 10, 5, false},
+	}
+	for _, test := range testsInt {
+		actual := InRange(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRange(%v, %v, %v) to be %v, got %v", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+
+	var testsFloat32 = []struct {
+		param    float32
+		left     float32
+		right    float32
+		expected bool
+	}{
+		{0, 0, 0, true},
+		{1, 0, 0, false},
+		{-1, 0, 0, false},
+		{0, -1, 1, true},
+		{0, 0, 1, true},
+		{0, -1, 0, true},
+		{0, 0, -1, true},
+		{0, 10, 5, false},
+	}
+	for _, test := range testsFloat32 {
+		actual := InRange(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRange(%v, %v, %v) to be %v, got %v", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+
+	var testsFloat64 = []struct {
+		param    float64
+		left     float64
+		right    float64
+		expected bool
+	}{
+		{0, 0, 0, true},
+		{1, 0, 0, false},
+		{-1, 0, 0, false},
+		{0, -1, 1, true},
+		{0, 0, 1, true},
+		{0, -1, 0, true},
+		{0, 0, -1, true},
+		{0, 10, 5, false},
+	}
+	for _, test := range testsFloat64 {
+		actual := InRange(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRange(%v, %v, %v) to be %v, got %v", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+
+	var testsTypeMix = []struct {
+		param    int
+		left     float64
+		right    float64
+		expected bool
+	}{
+		{0, 0, 0, false},
+		{1, 0, 0, false},
+		{-1, 0, 0, false},
+		{0, -1, 1, false},
+		{0, 0, 1, false},
+		{0, -1, 0, false},
+		{0, 0, -1, false},
+		{0, 10, 5, false},
+	}
+	for _, test := range testsTypeMix {
 		actual := InRange(test.param, test.left, test.right)
 		if actual != test.expected {
 			t.Errorf("Expected InRange(%v, %v, %v) to be %v, got %v", test.param, test.left, test.right, test.expected, actual)


### PR DESCRIPTION
**InRange** is backward compatible and now will handle int, float32 or float64 if any of the parameters are not of the same type boolean value **false** is returned.  InRange is just a simple wrapper to the 3 specific range checks:  **InRangeInt**, **InRangeFloat32**, **InRange64**.

Yes, in each of the specific implementations the code seems to be redundant but I believe this is unavoidable due to _Go_ being strictly typed.  We could convert them inside **InRange** and only have the one function (we would still have 3 sets of comparing logic due to strict type) but why not have the other functions for convenience.

Modified InRangeTest test all 3 support types and simple test where a mix of types are given (returns false).  As included unit tests for each the specific range checks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/239)
<!-- Reviewable:end -->
