### PR TITLE
Fixe for _ in URL makes them invalid #212

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -56,7 +56,13 @@ func IsURL(str string) bool {
 	if str == "" || utf8.RuneCountInString(str) >= maxURLRuneCount || len(str) <= minURLRuneCount || strings.HasPrefix(str, ".") {
 		return false
 	}
-	u, err := url.Parse(str)
+	strTemp := str
+	if strings.Index(str, ":") >= 0 && strings.Index(str, "://") == -1 {
+		// support no indicated urlscheme but with colon for port number
+		// http:// is appended so url.Parse will succeed, strTemp used so it does not impact rxURL.MatchString
+		strTemp = "http://" + str
+	}
+	u, err := url.Parse(strTemp)
 	if err != nil {
 		return false
 	}
@@ -67,7 +73,6 @@ func IsURL(str string) bool {
 		return false
 	}
 	return rxURL.MatchString(str)
-
 }
 
 // IsRequestURL check if the string rawurl, assuming

--- a/validator_test.go
+++ b/validator_test.go
@@ -661,6 +661,10 @@ func TestIsURL(t *testing.T) {
 		{"foo_bar.example.com", true},
 		{"foo_bar_fizz_buzz.example.com", true},
 		{"http://hello_world.example.com", true},
+		// According to #212
+		{"foo_bar-fizz-buzz:1313", true},
+		{"foo_bar-fizz-buzz:13:13", false},
+		{"foo_bar-fizz-buzz://1313", false},
 	}
 	for _, test := range tests {
 		actual := IsURL(test.param)


### PR DESCRIPTION
Fixed, now allows colon for port when Url Scheme doesn't exist.

The solution detects if there is a colon and no url scheme exits (searches for **://**) it then fakes out _url.Parse()_ by appending **http://** , originally I was thinking for specifically looking for either https or http based on the comment in the golang url.parse function the URL,"... _is assumed to have arrived via an HTTP request_", but because govalidator supports other schemes like ftp (see patterns.go).  The faked out url with the appended value is only used in urlParse.  The original given url is still used in the _rxURL.MatchString(str)_.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/240)
<!-- Reviewable:end -->
