### PR TITLE
Issue 236 - Add validators for HasLowerCase and HasUpperCase with unit tests

### DIFF
--- a/patterns.go
+++ b/patterns.go
@@ -43,6 +43,8 @@ const (
 	UnixPath       string = `^(/[^/\x00]*)+/?$`
 	Semver         string = "^v?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(-(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\\+[0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)?$"
 	tagName        string = "valid"
+	hasLowerCase   string = ".*[[:lower:]]"
+	hasUpperCase   string = ".*[[:upper:]]"
 )
 
 // Used by IsFilePath func
@@ -87,4 +89,6 @@ var (
 	rxWinPath        = regexp.MustCompile(WinPath)
 	rxUnixPath       = regexp.MustCompile(UnixPath)
 	rxSemver         = regexp.MustCompile(Semver)
+	rxHasLowerCase   = regexp.MustCompile(hasLowerCase)
+	rxHasUpperCase   = regexp.MustCompile(hasUpperCase)
 )

--- a/validator.go
+++ b/validator.go
@@ -231,6 +231,22 @@ func IsUpperCase(str string) bool {
 	return str == strings.ToUpper(str)
 }
 
+// HasLowerCase check if the string contains at least 1 lowercase. Empty string is valid.
+func HasLowerCase(str string) bool {
+    if IsNull(str) {
+        return true
+    }
+    return rxHasLowerCase.MatchString(str)
+}
+
+// HasUpperCase check if the string contians as least 1 uppercase. Empty string is valid.
+func HasUpperCase(str string) bool {
+    if IsNull(str) {
+        return true
+    }
+    return rxHasUpperCase.MatchString(str)
+}
+
 // IsInt check if the string is an integer. Empty string is valid.
 func IsInt(str string) bool {
 	if IsNull(str) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -499,6 +499,75 @@ func TestIsUpperCase(t *testing.T) {
 	}
 }
 
+func TestHasLowerCase(t *testing.T) {
+    t.Parallel()
+
+    var tests = []struct {
+        param    string
+        expected bool
+    }{
+        {"", true},
+        {"abc123", true},
+        {"abc", true},
+        {"a b c", true},
+        {"abcß", true},
+        {"abcẞ", true},
+        {"ABCẞ", false},
+        {"tr竪s 端ber", true},
+        {"fooBar", true},
+        {"123ABC", false},
+        {"ABC123", false},
+        {"ABC", false},
+        {"S T R", false},
+        {"fooBar", true},
+        {"abacaba123", true},
+        {"FÒÔBÀŘ", false},
+        {"fòôbàř", true},
+        {"fÒÔBÀŘ", true},
+        
+    }
+    for _, test := range tests {
+        actual := HasLowerCase(test.param)
+        if actual != test.expected {
+            t.Errorf("Expected HasLowerCase(%q) to be %v, got %v", test.param, test.expected, actual)
+        }
+    }
+}
+
+func TestHasUpperCase(t *testing.T) {
+    t.Parallel()
+
+    var tests = []struct {
+        param    string
+        expected bool
+    }{
+        {"", true},
+        {"abc123", false},
+        {"abc", false},
+        {"a b c", false},
+        {"abcß", false},
+        {"abcẞ", false},
+        {"ABCẞ", true},
+        {"tr竪s 端ber", false},
+        {"fooBar", true},
+        {"123ABC", true},
+        {"ABC123", true},
+        {"ABC", true},
+        {"S T R", true},
+        {"fooBar", true},
+        {"abacaba123", false},
+        {"FÒÔBÀŘ", true},
+        {"fòôbàř", false},
+        {"Fòôbàř", true},
+    }
+    for _, test := range tests {
+        actual := HasUpperCase(test.param)
+        if actual != test.expected {
+            t.Errorf("Expected HasUpperCase(%q) to be %v, got %v", test.param, test.expected, actual)
+        }
+    }
+}
+
 func TestIsInt(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
There is already **IsLowerCase** and **IsUpperCase**, which makes consistent with what other string libraries do.  

**HasLowerCase** checks if there is at least one character that is lower case, if so returns true.  In keeping with consistency with IsLowerCase when the string is NULL, true is returned.

**HasUpperCase** checks if there is at least one character that is upper case, if so returns true.  In keeping with consistency with IsUpperCase when the string is NULL, true is returned.

Instead of appending the new validators at the end of the _validators.go_ file I put them near IsLowerCase and IsUpperCase, thinking it makes more sense from a grouping perspective.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/241)
<!-- Reviewable:end -->
