### PR TITLE
Feature/fix wrong error msg when required field is not set

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -890,7 +890,7 @@ func checkRequired(v reflect.Value, t reflect.StructField, options tagOptionsMap
 		}
 		return false, Error{t.Name, fmt.Errorf("non zero value required"), false, "required"}
 	} else if _, isOptional := options["optional"]; fieldsRequiredByDefault && !isOptional {
-		return false, Error{t.Name, fmt.Errorf("All fields are required to at least have one validation defined"), false, "required"}
+		return false, Error{t.Name, fmt.Errorf("Missing required field"), false, "required"}
 	}
 	// not required and empty is valid
 	return true, nil

--- a/validator_test.go
+++ b/validator_test.go
@@ -2116,6 +2116,15 @@ type MissingValidationDeclarationStruct struct {
 	Email string `valid:"required,email"`
 }
 
+type FieldRequiredByDefault struct {
+    Email string `valid:"email"`
+}
+
+type MultipleFieldsRequiredByDefault struct {
+    Url string `valid:"url"`
+    Email string `valid:"email"`
+}
+
 type FieldsRequiredByDefaultButExemptStruct struct {
 	Name  string `valid:"-"`
 	Email string `valid:"email"`
@@ -2150,6 +2159,46 @@ func TestValidateMissingValidationDeclarationStruct(t *testing.T) {
 		}
 	}
 	SetFieldsRequiredByDefault(false)
+}
+
+func TestFieldRequiredByDefault(t *testing.T) {
+    var tests = []struct {
+        param    FieldRequiredByDefault
+        expected bool
+    }{
+        {FieldRequiredByDefault{}, true},
+    }
+    SetFieldsRequiredByDefault(true)
+    for _, test := range tests {
+        actual, err := ValidateStruct(test.param)
+        if actual != test.expected {
+            t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
+            if err != nil {
+                t.Errorf("Got Error on ValidateStruct(%q): %s", test.param, err)
+            }
+        }
+    }
+    SetFieldsRequiredByDefault(false)
+}
+
+func TestMultipleFieldsRequiredByDefault(t *testing.T) {
+    var tests = []struct {
+        param    MultipleFieldsRequiredByDefault
+        expected bool
+    }{
+        {MultipleFieldsRequiredByDefault{}, true},
+    }
+    SetFieldsRequiredByDefault(true)
+    for _, test := range tests {
+        actual, err := ValidateStruct(test.param)
+        if actual != test.expected {
+            t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
+            if err != nil {
+                t.Errorf("Got Error on ValidateStruct(%q): %s", test.param, err)
+            }
+        }
+    }
+    SetFieldsRequiredByDefault(false)
 }
 
 func TestFieldsRequiredByDefaultButExemptStruct(t *testing.T) {


### PR DESCRIPTION
Updated error message (see Issue #220), there really is no output in the unit test other then checking that it did fail.  But if you manually break the test by setting the expected "false" to "true" then you will see the appropriate new message:

--- FAIL: TestFieldRequiredByDefault (0.00s)
    validator_test.go:2175: Expected ValidateStruct({""}) to be true, got false
    validator_test.go:2177: Got Error on ValidateStruct({""}): Email: Missing required field
=== RUN   TestMultipleFieldsRequiredByDefault
--- FAIL: TestMultipleFieldsRequiredByDefault (0.00s)
    validator_test.go:2195: Expected ValidateStruct({"" ""}) to be true, got false
    validator_test.go:2197: Got Error on ValidateStruct({"" ""}): Url: Missing required field;Email: Missing required field

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/242)
<!-- Reviewable:end -->
