### PR TITLE
Feature/refactor to int and in range int

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -31,6 +31,7 @@ func ToFloat(str string) (float64, error) {
 	return res, err
 }
 
+// ToInt convert the input string or any int type to an integer type 64, or 0 if the input is not an integer.
 func ToInt(value interface{}) (res int64, err error) {
 	val := reflect.ValueOf(value)
 

--- a/converter.go
+++ b/converter.go
@@ -31,15 +31,6 @@ func ToFloat(str string) (float64, error) {
 	return res, err
 }
 
-// ToInt convert the input string to an integer, or 0 if the input is not an integer.
-func ToIntX(str string) (int64, error) {
-	res, err := strconv.ParseInt(str, 0, 64)
-	if err != nil {
-		res = 0
-	}
-	return res, err
-}
-
 func ToInt(value interface{}) (res int64, err error) {
 	val := reflect.ValueOf(value)
 

--- a/converter.go
+++ b/converter.go
@@ -3,6 +3,7 @@ package govalidator
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 )
 
@@ -31,12 +32,38 @@ func ToFloat(str string) (float64, error) {
 }
 
 // ToInt convert the input string to an integer, or 0 if the input is not an integer.
-func ToInt(str string) (int64, error) {
+func ToIntX(str string) (int64, error) {
 	res, err := strconv.ParseInt(str, 0, 64)
 	if err != nil {
 		res = 0
 	}
 	return res, err
+}
+
+func ToInt(value interface{}) (res int64, err error) {
+	val := reflect.ValueOf(value)
+
+	switch value.(type) {
+	case int, int8, int16, int32, int64:
+		res = val.Int()
+	case uint, uint8, uint16, uint32, uint64:
+		res = int64(val.Uint())
+	case string:
+		if IsInt(val.String()) {
+			res, err = strconv.ParseInt(val.String(), 0, 64)
+			if err != nil {
+				res = 0
+			}
+		} else {
+			err = fmt.Errorf("math: square root of negative number %g", value)
+			res = 0
+		}
+	default:
+		err = fmt.Errorf("math: square root of negative number %g", value)
+		res = 0
+	}
+
+	return
 }
 
 // ToBoolean convert the input string to a boolean.

--- a/numerics.go
+++ b/numerics.go
@@ -42,11 +42,14 @@ func IsNonPositive(value float64) bool {
 }
 
 // InRange returns true if value lies between left and right border
-func InRangeInt(value, left, right int) bool {
-	if left > right {
-		left, right = right, left
+func InRangeInt(value, left, right interface{}) bool {
+	value64, _ := ToInt(value)
+	left64, _ := ToInt(left)
+	right64, _ := ToInt(right)
+	if left64 > right64 {
+		left64, right64 = right64, left64
 	}
-	return value >= left && value <= right
+	return value64 >= left64 && value64 <= right64
 }
 
 // InRange returns true if value lies between left and right border

--- a/numerics_test.go
+++ b/numerics_test.go
@@ -181,7 +181,7 @@ func TestIsNatural(t *testing.T) {
 func TestInRangeInt(t *testing.T) {
 	t.Parallel()
 
-	var tests = []struct {
+	var testAsInts = []struct {
 		param    int
 		left     int
 		right    int
@@ -196,10 +196,210 @@ func TestInRangeInt(t *testing.T) {
 		{0, 0, -1, true},
 		{0, 10, 5, false},
 	}
-	for _, test := range tests {
+	for _, test := range testAsInts {
 		actual := InRangeInt(test.param, test.left, test.right)
 		if actual != test.expected {
-			t.Errorf("Expected InRangeInt(%v, %v, %v) to be %v, got %v", test.param, test.left, test.right, test.expected, actual)
+			t.Errorf("Expected InRangeInt(%v, %v, %v) to be %v, got %v using type int", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+
+	var testAsInt8s = []struct {
+		param    int8
+		left     int8
+		right    int8
+		expected bool
+	}{
+		{0, 0, 0, true},
+		{1, 0, 0, false},
+		{-1, 0, 0, false},
+		{0, -1, 1, true},
+		{0, 0, 1, true},
+		{0, -1, 0, true},
+		{0, 0, -1, true},
+		{0, 10, 5, false},
+	}
+	for _, test := range testAsInt8s {
+		actual := InRangeInt(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRangeInt(%v, %v, %v) to be %v, got %v using type int8", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+
+	var testAsInt16s = []struct {
+		param    int16
+		left     int16
+		right    int16
+		expected bool
+	}{
+		{0, 0, 0, true},
+		{1, 0, 0, false},
+		{-1, 0, 0, false},
+		{0, -1, 1, true},
+		{0, 0, 1, true},
+		{0, -1, 0, true},
+		{0, 0, -1, true},
+		{0, 10, 5, false},
+	}
+	for _, test := range testAsInt16s {
+		actual := InRangeInt(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRangeInt(%v, %v, %v) to be %v, got %v using type int16", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+
+	var testAsInt32s = []struct {
+		param    int32
+		left     int32
+		right    int32
+		expected bool
+	}{
+		{0, 0, 0, true},
+		{1, 0, 0, false},
+		{-1, 0, 0, false},
+		{0, -1, 1, true},
+		{0, 0, 1, true},
+		{0, -1, 0, true},
+		{0, 0, -1, true},
+		{0, 10, 5, false},
+	}
+	for _, test := range testAsInt32s {
+		actual := InRangeInt(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRangeInt(%v, %v, %v) to be %v, got %v using type int32", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+
+	var testAsInt64s = []struct {
+		param    int64
+		left     int64
+		right    int64
+		expected bool
+	}{
+		{0, 0, 0, true},
+		{1, 0, 0, false},
+		{-1, 0, 0, false},
+		{0, -1, 1, true},
+		{0, 0, 1, true},
+		{0, -1, 0, true},
+		{0, 0, -1, true},
+		{0, 10, 5, false},
+	}
+	for _, test := range testAsInt64s {
+		actual := InRangeInt(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRangeInt(%v, %v, %v) to be %v, got %v using type int64", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+
+	var testAsUInts = []struct {
+		param    uint
+		left     uint
+		right    uint
+		expected bool
+	}{
+		{0, 0, 0, true},
+		{1, 0, 0, false},
+		{0, 0, 1, true},
+		{0, 10, 5, false},
+	}
+	for _, test := range testAsUInts {
+		actual := InRangeInt(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRangeInt(%v, %v, %v) to be %v, got %v using type uint", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+
+	var testAsUInt8s = []struct {
+		param    uint8
+		left     uint8
+		right    uint8
+		expected bool
+	}{
+		{0, 0, 0, true},
+		{1, 0, 0, false},
+		{0, 0, 1, true},
+		{0, 10, 5, false},
+	}
+	for _, test := range testAsUInt8s {
+		actual := InRangeInt(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRangeInt(%v, %v, %v) to be %v, got %v using type uint", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+
+	var testAsUInt16s = []struct {
+		param    uint16
+		left     uint16
+		right    uint16
+		expected bool
+	}{
+		{0, 0, 0, true},
+		{1, 0, 0, false},
+		{0, 0, 1, true},
+		{0, 10, 5, false},
+	}
+	for _, test := range testAsUInt16s {
+		actual := InRangeInt(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRangeInt(%v, %v, %v) to be %v, got %v using type uint", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+
+	var testAsUInt32s = []struct {
+		param    uint32
+		left     uint32
+		right    uint32
+		expected bool
+	}{
+		{0, 0, 0, true},
+		{1, 0, 0, false},
+		{0, 0, 1, true},
+		{0, 10, 5, false},
+	}
+	for _, test := range testAsUInt32s {
+		actual := InRangeInt(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRangeInt(%v, %v, %v) to be %v, got %v using type uint", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+
+	var testAsUInt64s = []struct {
+		param    uint64
+		left     uint64
+		right    uint64
+		expected bool
+	}{
+		{0, 0, 0, true},
+		{1, 0, 0, false},
+		{0, 0, 1, true},
+		{0, 10, 5, false},
+	}
+	for _, test := range testAsUInt64s {
+		actual := InRangeInt(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRangeInt(%v, %v, %v) to be %v, got %v using type uint", test.param, test.left, test.right, test.expected, actual)
+		}
+	}
+
+	var testAsStrings = []struct {
+		param    string
+		left     string
+		right    string
+		expected bool
+	}{
+		{"0", "0", "0", true},
+		{"1", "0", "0", false},
+		{"-1", "0", "0", false},
+		{"0", "-1", "1", true},
+		{"0", "0", "1", true},
+		{"0", "-1", "0", true},
+		{"0", "0", "-1", true},
+		{"0", "10", "5", false},
+	}
+	for _, test := range testAsStrings {
+		actual := InRangeInt(test.param, test.left, test.right)
+		if actual != test.expected {
+			t.Errorf("Expected InRangeInt(%v, %v, %v) to be %v, got %v using type string", test.param, test.left, test.right, test.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
… and updated InRangeInt (numerics.go) to handle all int types not just type int.

Previously InRangeInt could only handle type int.  Yes, any uint type ---> any int type may result in  lost or misinterpreted data... we could alternatively not support any uint but I think it's more of a developers responsibility to know what he/she is converting.

As well, looking at issue #223 one approach is to update **Range** to handle any int type, float32 and float64 which was another reason for updating InRangeInt to be versatile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/248)
<!-- Reviewable:end -->
