### PR TITLE
 Validate the child struct if it's a pointer

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -233,18 +233,18 @@ func IsUpperCase(str string) bool {
 
 // HasLowerCase check if the string contains at least 1 lowercase. Empty string is valid.
 func HasLowerCase(str string) bool {
-    if IsNull(str) {
-        return true
-    }
-    return rxHasLowerCase.MatchString(str)
+	if IsNull(str) {
+		return true
+	}
+	return rxHasLowerCase.MatchString(str)
 }
 
 // HasUpperCase check if the string contians as least 1 uppercase. Empty string is valid.
 func HasUpperCase(str string) bool {
-    if IsNull(str) {
-        return true
-    }
-    return rxHasUpperCase.MatchString(str)
+	if IsNull(str) {
+		return true
+	}
+	return rxHasUpperCase.MatchString(str)
 }
 
 // IsInt check if the string is an integer. Empty string is valid.
@@ -539,7 +539,7 @@ func IsHash(str string, algorithm string) bool {
 		return false
 	}
 
-	return Matches(str, "^[a-f0-9]{" + len + "}$")
+	return Matches(str, "^[a-f0-9]{"+len+"}$")
 }
 
 // IsDialString validates the given string for usage with the various Dial() functions
@@ -694,7 +694,9 @@ func ValidateStruct(s interface{}) (bool, error) {
 			continue // Private field
 		}
 		structResult := true
-		if valueField.Kind() == reflect.Struct && typeField.Tag.Get(tagName) != "-" {
+		if (valueField.Kind() == reflect.Struct ||
+			(valueField.Kind() == reflect.Ptr && valueField.Elem().Kind() == reflect.Struct)) &&
+			typeField.Tag.Get(tagName) != "-" {
 			var err error
 			structResult, err = ValidateStruct(valueField.Interface())
 			if err != nil {

--- a/validator_test.go
+++ b/validator_test.go
@@ -500,72 +500,71 @@ func TestIsUpperCase(t *testing.T) {
 }
 
 func TestHasLowerCase(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    var tests = []struct {
-        param    string
-        expected bool
-    }{
-        {"", true},
-        {"abc123", true},
-        {"abc", true},
-        {"a b c", true},
-        {"abcß", true},
-        {"abcẞ", true},
-        {"ABCẞ", false},
-        {"tr竪s 端ber", true},
-        {"fooBar", true},
-        {"123ABC", false},
-        {"ABC123", false},
-        {"ABC", false},
-        {"S T R", false},
-        {"fooBar", true},
-        {"abacaba123", true},
-        {"FÒÔBÀŘ", false},
-        {"fòôbàř", true},
-        {"fÒÔBÀŘ", true},
-        
-    }
-    for _, test := range tests {
-        actual := HasLowerCase(test.param)
-        if actual != test.expected {
-            t.Errorf("Expected HasLowerCase(%q) to be %v, got %v", test.param, test.expected, actual)
-        }
-    }
+	var tests = []struct {
+		param    string
+		expected bool
+	}{
+		{"", true},
+		{"abc123", true},
+		{"abc", true},
+		{"a b c", true},
+		{"abcß", true},
+		{"abcẞ", true},
+		{"ABCẞ", false},
+		{"tr竪s 端ber", true},
+		{"fooBar", true},
+		{"123ABC", false},
+		{"ABC123", false},
+		{"ABC", false},
+		{"S T R", false},
+		{"fooBar", true},
+		{"abacaba123", true},
+		{"FÒÔBÀŘ", false},
+		{"fòôbàř", true},
+		{"fÒÔBÀŘ", true},
+	}
+	for _, test := range tests {
+		actual := HasLowerCase(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected HasLowerCase(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+	}
 }
 
 func TestHasUpperCase(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    var tests = []struct {
-        param    string
-        expected bool
-    }{
-        {"", true},
-        {"abc123", false},
-        {"abc", false},
-        {"a b c", false},
-        {"abcß", false},
-        {"abcẞ", false},
-        {"ABCẞ", true},
-        {"tr竪s 端ber", false},
-        {"fooBar", true},
-        {"123ABC", true},
-        {"ABC123", true},
-        {"ABC", true},
-        {"S T R", true},
-        {"fooBar", true},
-        {"abacaba123", false},
-        {"FÒÔBÀŘ", true},
-        {"fòôbàř", false},
-        {"Fòôbàř", true},
-    }
-    for _, test := range tests {
-        actual := HasUpperCase(test.param)
-        if actual != test.expected {
-            t.Errorf("Expected HasUpperCase(%q) to be %v, got %v", test.param, test.expected, actual)
-        }
-    }
+	var tests = []struct {
+		param    string
+		expected bool
+	}{
+		{"", true},
+		{"abc123", false},
+		{"abc", false},
+		{"a b c", false},
+		{"abcß", false},
+		{"abcẞ", false},
+		{"ABCẞ", true},
+		{"tr竪s 端ber", false},
+		{"fooBar", true},
+		{"123ABC", true},
+		{"ABC123", true},
+		{"ABC", true},
+		{"S T R", true},
+		{"fooBar", true},
+		{"abacaba123", false},
+		{"FÒÔBÀŘ", true},
+		{"fòôbàř", false},
+		{"Fòôbàř", true},
+	}
+	for _, test := range tests {
+		actual := HasUpperCase(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected HasUpperCase(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+	}
 }
 
 func TestIsInt(t *testing.T) {
@@ -605,13 +604,12 @@ func TestIsInt(t *testing.T) {
 	}
 }
 
-
 func TestIsHash(t *testing.T) {
 	t.Parallel()
 
 	var tests = []struct {
 		param    string
-		algo 	 string
+		algo     string
 		expected bool
 	}{
 		{"3ca25ae354e192b26879f651a51d92aa8a34d8d3", "sha1", true},
@@ -2186,12 +2184,12 @@ type MissingValidationDeclarationStruct struct {
 }
 
 type FieldRequiredByDefault struct {
-    Email string `valid:"email"`
+	Email string `valid:"email"`
 }
 
 type MultipleFieldsRequiredByDefault struct {
-    Url string `valid:"url"`
-    Email string `valid:"email"`
+	Url   string `valid:"url"`
+	Email string `valid:"email"`
 }
 
 type FieldsRequiredByDefaultButExemptStruct struct {
@@ -2231,43 +2229,43 @@ func TestValidateMissingValidationDeclarationStruct(t *testing.T) {
 }
 
 func TestFieldRequiredByDefault(t *testing.T) {
-    var tests = []struct {
-        param    FieldRequiredByDefault
-        expected bool
-    }{
-        {FieldRequiredByDefault{}, false},
-    }
-    SetFieldsRequiredByDefault(true)
-    for _, test := range tests {
-        actual, err := ValidateStruct(test.param)
-        if actual != test.expected {
-            t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
-            if err != nil {
-                t.Errorf("Got Error on ValidateStruct(%q): %s", test.param, err)
-            }
-        }
-    }
-    SetFieldsRequiredByDefault(false)
+	var tests = []struct {
+		param    FieldRequiredByDefault
+		expected bool
+	}{
+		{FieldRequiredByDefault{}, false},
+	}
+	SetFieldsRequiredByDefault(true)
+	for _, test := range tests {
+		actual, err := ValidateStruct(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
+			if err != nil {
+				t.Errorf("Got Error on ValidateStruct(%q): %s", test.param, err)
+			}
+		}
+	}
+	SetFieldsRequiredByDefault(false)
 }
 
 func TestMultipleFieldsRequiredByDefault(t *testing.T) {
-    var tests = []struct {
-        param    MultipleFieldsRequiredByDefault
-        expected bool
-    }{
-        {MultipleFieldsRequiredByDefault{}, false},
-    }
-    SetFieldsRequiredByDefault(true)
-    for _, test := range tests {
-        actual, err := ValidateStruct(test.param)
-        if actual != test.expected {
-            t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
-            if err != nil {
-                t.Errorf("Got Error on ValidateStruct(%q): %s", test.param, err)
-            }
-        }
-    }
-    SetFieldsRequiredByDefault(false)
+	var tests = []struct {
+		param    MultipleFieldsRequiredByDefault
+		expected bool
+	}{
+		{MultipleFieldsRequiredByDefault{}, false},
+	}
+	SetFieldsRequiredByDefault(true)
+	for _, test := range tests {
+		actual, err := ValidateStruct(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
+			if err != nil {
+				t.Errorf("Got Error on ValidateStruct(%q): %s", test.param, err)
+			}
+		}
+	}
+	SetFieldsRequiredByDefault(false)
 }
 
 func TestFieldsRequiredByDefaultButExemptStruct(t *testing.T) {
@@ -2653,6 +2651,7 @@ func TestValidateStruct(t *testing.T) {
 		{User{"John", "", "12345", 0, &Address{"Street", "123456789"}, []Address{{"Street", "ABC456D89"}, {"Street", "123456"}}}, false},
 		{UserValid{"John", "john@yahoo.com", "123G#678", 20, &Address{"Street", "123456"}, []Address{{"Street", "123456"}, {"Street", "123456"}}}, true},
 		{UserValid{"John", "john!yahoo.com", "12345678", 20, &Address{"Street", "ABC456D89"}, []Address{}}, false},
+		{UserValid{"John", "john@yahoo.com", "12345678", 20, &Address{"Street", "123456xxx"}, []Address{{"Street", "123456"}, {"Street", "123456"}}}, false},
 		{UserValid{"John", "john!yahoo.com", "12345678", 20, &Address{"Street", "ABC456D89"}, []Address{{"Street", "ABC456D89"}, {"Street", "123456"}}}, false},
 		{UserValid{"John", "", "12345", 0, &Address{"Street", "123456789"}, []Address{{"Street", "ABC456D89"}, {"Street", "123456"}}}, false},
 		{nil, true},

--- a/validator_test.go
+++ b/validator_test.go
@@ -2660,9 +2660,6 @@ func TestValidateStruct(t *testing.T) {
 	}
 	for _, test := range tests {
 		actual, err := ValidateStruct(test.param)
-		//		if err != nil {
-		//			t.Errorf("%+v", err)
-		//		}
 		if actual != test.expected {
 			t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
 			if err != nil {


### PR DESCRIPTION
This fixes https://github.com/asaskevich/govalidator/issues/210
The diff is quite big because gofmt went through the test file.

Strange thing that test had substructs as pointers, but in fact, the validation of these structs didn't work.
I've added another example to the test to verify exactly this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/249)
<!-- Reviewable:end -->
