### PR TITLE
validator_test: remove invalid irc:// URLs

### DIFF
--- a/validator_test.go
+++ b/validator_test.go
@@ -811,7 +811,6 @@ func TestIsRequestURL(t *testing.T) {
 		{"http://www.foo---bar.com/", true},
 		{"mailto:someone@example.com", true},
 		{"irc://irc.server.org/channel", true},
-		{"irc://#channel@network", true},
 		{"/abs/test/dir", false},
 		{"./rel/test/dir", false},
 	}
@@ -860,7 +859,6 @@ func TestIsRequestURI(t *testing.T) {
 		{"http://www.foo---bar.com/", true},
 		{"mailto:someone@example.com", true},
 		{"irc://irc.server.org/channel", true},
-		{"irc://#channel@network", true},
 		{"/abs/test/dir", true},
 		{"./rel/test/dir", false},
 	}


### PR DESCRIPTION
The previously-used URL format is not valid as per either of these two:
https://www.w3.org/Addressing/draft-mirashi-url-irc-01.txt
https://www-archive.mozilla.org/projects/rt-messaging/chatzilla/irc-urls.html

Further, Go’s net/url package no longer parses the syntax as of
https://github.com/golang/go/commit/ba1018b4549f3edc257221cc8e49221255e03290

fixes #250
related to https://github.com/golang/go/issues/23657

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/257)
<!-- Reviewable:end -->
