### PR TITLE
Add support for ParamValidator functions to process integers

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -1012,7 +1012,11 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 				delete(options, validatorSpec)
 
 				switch v.Kind() {
-				case reflect.String:
+				case reflect.String,
+					reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+					reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+					reflect.Float32, reflect.Float64:
+
 					field := fmt.Sprint(v) // make value into string, then validate with regex
 					if result := validatefunc(field, ps[1:]...); (!result && !negate) || (result && negate) {
 						if customMsgExists {

--- a/validator_test.go
+++ b/validator_test.go
@@ -3012,7 +3012,7 @@ func TestValidateStructParamValidatorInt(t *testing.T) {
 		Uint32 uint32 `valid:"in(1|10)"`
 		Uint64 uint64 `valid:"in(1|10)"`
 
-		Flaot32 float32 `valid:"in(1|10)"`
+		Float32 float32 `valid:"in(1|10)"`
 		Float64 float64 `valid:"in(1|10)"`
 	}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -2983,7 +2983,7 @@ func TestValidateStructParamValidatorInt(t *testing.T) {
 		Uint32 uint32 `valid:"range(1|10)"`
 		Uint64 uint64 `valid:"range(1|10)"`
 
-		Flaot32 float32 `valid:"range(1|10)"`
+		Float32 float32 `valid:"range(1|10)"`
 		Float64 float64 `valid:"range(1|10)"`
 	}
 	test1Ok := &Test1{5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5}

--- a/validator_test.go
+++ b/validator_test.go
@@ -2969,6 +2969,73 @@ func ExampleValidateStruct() {
 	println(result)
 }
 
+func TestValidateStructParamValidatorInt(t *testing.T) {
+	type Test1 struct {
+		Int   int   `valid:"range(1|10)"`
+		Int8  int8  `valid:"range(1|10)"`
+		Int16 int16 `valid:"range(1|10)"`
+		Int32 int32 `valid:"range(1|10)"`
+		Int64 int64 `valid:"range(1|10)"`
+
+		Uint   uint   `valid:"range(1|10)"`
+		Uint8  uint8  `valid:"range(1|10)"`
+		Uint16 uint16 `valid:"range(1|10)"`
+		Uint32 uint32 `valid:"range(1|10)"`
+		Uint64 uint64 `valid:"range(1|10)"`
+
+		Flaot32 float32 `valid:"range(1|10)"`
+		Float64 float64 `valid:"range(1|10)"`
+	}
+	test1Ok := &Test1{5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5}
+	test1NotOk := &Test1{11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11}
+
+	_, err := ValidateStruct(test1Ok)
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	_, err = ValidateStruct(test1NotOk)
+	if err == nil {
+		t.Errorf("Test failed: nil")
+	}
+
+	type Test2 struct {
+		Int   int   `valid:"in(1|10)"`
+		Int8  int8  `valid:"in(1|10)"`
+		Int16 int16 `valid:"in(1|10)"`
+		Int32 int32 `valid:"in(1|10)"`
+		Int64 int64 `valid:"in(1|10)"`
+
+		Uint   uint   `valid:"in(1|10)"`
+		Uint8  uint8  `valid:"in(1|10)"`
+		Uint16 uint16 `valid:"in(1|10)"`
+		Uint32 uint32 `valid:"in(1|10)"`
+		Uint64 uint64 `valid:"in(1|10)"`
+
+		Flaot32 float32 `valid:"in(1|10)"`
+		Float64 float64 `valid:"in(1|10)"`
+	}
+
+	test2Ok1 := &Test2{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	test2Ok2 := &Test2{10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10}
+	test2NotOk := &Test2{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2}
+
+	_, err = ValidateStruct(test2Ok1)
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	_, err = ValidateStruct(test2Ok2)
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
+
+	_, err = ValidateStruct(test2NotOk)
+	if err == nil {
+		t.Errorf("Test failed: nil")
+	}
+}
+
 func TestIsCIDR(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
That's a quick fix to support basic stuff like **range()** **in()** validation tags on integer and float types in structs.

It's not much efficient because govalidator is doing int -> str -> int double conversion behind the scenes, but I guess that can be improved in future without breaking the API.

Test included.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/263)
<!-- Reviewable:end -->
