### PR TITLE
Remove broken IRC URL parsing test.

### DIFF
--- a/validator_test.go
+++ b/validator_test.go
@@ -811,7 +811,6 @@ func TestIsRequestURL(t *testing.T) {
 		{"http://www.foo---bar.com/", true},
 		{"mailto:someone@example.com", true},
 		{"irc://irc.server.org/channel", true},
-		{"irc://#channel@network", true},
 		{"/abs/test/dir", false},
 		{"./rel/test/dir", false},
 	}
@@ -860,7 +859,6 @@ func TestIsRequestURI(t *testing.T) {
 		{"http://www.foo---bar.com/", true},
 		{"mailto:someone@example.com", true},
 		{"irc://irc.server.org/channel", true},
-		{"irc://#channel@network", true},
 		{"/abs/test/dir", true},
 		{"./rel/test/dir", false},
 	}


### PR DESCRIPTION
Go's parser gives the error below. I think it is not expected to parse IRC URLs
like this one:

parse irc://#channel@network: net/url: invalid userinfo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/264)
<!-- Reviewable:end -->
