### PR TITLE
Validator: Adding more concrete base64 validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ Here is a list of available validators for struct fields (validator - used funct
 "halfwidth":          IsHalfWidth,
 "variablewidth":      IsVariableWidth,
 "base64":             IsBase64,
+"base64string":       IsBase64String,
+"base64rawstring":    IsBase64RawString,
 "datauri":            IsDataURI,
 "ip":                 IsIP,
 "port":               IsPort,

--- a/types.go
+++ b/types.go
@@ -109,6 +109,8 @@ var TagMap = map[string]Validator{
 	"halfwidth":          IsHalfWidth,
 	"variablewidth":      IsVariableWidth,
 	"base64":             IsBase64,
+	"base64string":       IsBase64String,
+	"base64rawstring":    IsBase64RawString,
 	"datauri":            IsDataURI,
 	"ip":                 IsIP,
 	"port":               IsPort,

--- a/validator.go
+++ b/validator.go
@@ -468,9 +468,35 @@ func IsVariableWidth(str string) bool {
 	return rxHalfWidth.MatchString(str) && rxFullWidth.MatchString(str)
 }
 
-// IsBase64 check if a string is base64 encoded.
+// IsBase64 check if a string is data:base64 encoded.
 func IsBase64(str string) bool {
 	return rxBase64.MatchString(str)
+}
+
+// IsBase64String check to see if the string raw inputted string is a valid base64
+func IsBase64String(str string) bool {
+	if len(str) == 0 {
+		return false
+	}
+
+	_, err := base64.URLEncoding.DecodeString(str)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+// IsBase64RawString check to see if the string raw inputted (no == at the end) string is a valid base64
+func IsBase64RawString(str string) bool {
+	if len(str) == 0 {
+		return false
+	}
+
+	_, err := base64.RawURLEncoding.DecodeString(str)
+	if err != nil {
+		return false
+	}
+	return true
 }
 
 // IsFilePath check is a string is Win or Unix file path and returns it's type.

--- a/validator_test.go
+++ b/validator_test.go
@@ -1483,6 +1483,62 @@ func TestIsBase64(t *testing.T) {
 	}
 }
 
+func TestIsBase64String(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		param    string
+		expected bool
+	}{
+		{"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4=", true},
+		{"Vml2YW11cyBmZXJtZW50dW0gc2VtcGVyIHBvcnRhLg==", true},
+		{"U3VzcGVuZGlzc2UgbGVjdHVzIGxlbw==", true},
+		{"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuMPNS1Ufof9EW/M98FNw" +
+			"UAKrwflsqVxaxQjBQnHQmiI7Vac40t8x7pIb8gLGV6wL7sBTJiPovJ0V7y7oc0Ye" +
+			"rhKh0Rm4skP2z/jHwwZICgGzBvA0rH8xlhUiTvcwDCJ0kc+fh35hNt8srZQM4619" +
+			"FTgB66Xmp4EtVyhpQV+t02g6NzK72oZI0vnAvqhpkxLeLiMCyrI416wHm5Tkukhx" +
+			"QmcL2a6hNOyu0ixX/x2kSFXApEnVrJ+/IxGyfyw8kf4N2IZpW5nEP847lpfj0SZZ" +
+			"Fwrd1mnfnDbYohX2zRptLy2ZUn06Qo9pkG5ntvFEPo9bfZeULtjYzIl6K8gJ2uGZ" + "HQIDAQAB", false},
+		{"12345", false},
+		{"", false},
+		{"Vml2YW11cyBmZXJtZtesting123", false},
+	}
+	for _, test := range tests {
+		actual := IsBase64String(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected IsBase64(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+	}
+}
+
+func TestIsBase64RawString(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		param    string
+		expected bool
+	}{
+		{"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4", true},
+		{"Vml2YW11cyBmZXJtZW50dW0gc2VtcGVyIHBvcnRhLg", true},
+		{"U3VzcGVuZGlzc2UgbGVjdHVzIGxlbw", true},
+		{"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuMPNS1Ufof9EW/M98FNw" +
+			"UAKrwflsqVxaxQjBQnHQmiI7Vac40t8x7pIb8gLGV6wL7sBTJiPovJ0V7y7oc0Ye" +
+			"rhKh0Rm4skP2z/jHwwZICgGzBvA0rH8xlhUiTvcwDCJ0kc+fh35hNt8srZQM4619" +
+			"FTgB66Xmp4EtVyhpQV+t02g6NzK72oZI0vnAvqhpkxLeLiMCyrI416wHm5Tkukhx" +
+			"QmcL2a6hNOyu0ixX/x2kSFXApEnVrJ+/IxGyfyw8kf4N2IZpW5nEP847lpfj0SZZ" +
+			"Fwrd1mnfnDbYohX2zRptLy2ZUn06Qo9pkG5ntvFEPo9bfZeULtjYzIl6K8gJ2uGZ" + "HQIDAQAB", false},
+		{"12345", false},
+		{"", false},
+		{"Vml2YW11cyBmZXJtZtesting123", true},
+	}
+	for _, test := range tests {
+		actual := IsBase64RawString(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected IsBase64(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+	}
+}
+
 func TestIsISO3166Alpha2(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The current base64 validator makes a few assumptions about the nature
of the base 64 string as a result of using regex.
By using Go's build in base64 lib we circumvent the regex as well as
adding full functionally to validate both standard base64 strings
and raw base64 strings.
This is an additive string, which allows for full backwards capabilities.