### PR TITLE
Ensuring order on validation rules. Passing input and validator tag to custom error messages. Allowing nil values to pass validation. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 govalidator
 ===========
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/asaskevich/govalidator?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) [![GoDoc](https://godoc.org/github.com/asaskevich/govalidator?status.png)](https://godoc.org/github.com/asaskevich/govalidator) [![Coverage Status](https://img.shields.io/coveralls/asaskevich/govalidator.svg)](https://coveralls.io/r/asaskevich/govalidator?branch=master) [![wercker status](https://app.wercker.com/status/1ec990b09ea86c910d5f08b0e02c6043/s "wercker status")](https://app.wercker.com/project/bykey/1ec990b09ea86c910d5f08b0e02c6043)
-[![Build Status](https://travis-ci.org/asaskevich/govalidator.svg?branch=master)](https://travis-ci.org/asaskevich/govalidator) [![Go Report Card](https://goreportcard.com/badge/github.com/asaskevich/govalidator)](https://goreportcard.com/report/github.com/asaskevich/govalidator) [![GoSearch](http://go-search.org/badge?id=github.com%2Fasaskevich%2Fgovalidator)](http://go-search.org/view?id=github.com%2Fasaskevich%2Fgovalidator) [![Backers on Open Collective](https://opencollective.com/govalidator/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/govalidator/sponsors/badge.svg)](#sponsors) 
+[![Build Status](https://travis-ci.org/asaskevich/govalidator.svg?branch=master)](https://travis-ci.org/asaskevich/govalidator) [![Go Report Card](https://goreportcard.com/badge/github.com/asaskevich/govalidator)](https://goreportcard.com/report/github.com/asaskevich/govalidator) [![GoSearch](http://go-search.org/badge?id=github.com%2Fasaskevich%2Fgovalidator)](http://go-search.org/view?id=github.com%2Fasaskevich%2Fgovalidator) [![Backers on Open Collective](https://opencollective.com/govalidator/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/govalidator/sponsors/badge.svg)](#sponsors)
 
 A package of validators and sanitizers for strings, structs and collections. Based on [validator.js](https://github.com/chriso/validator.js).
 
@@ -32,6 +32,8 @@ import (
 
 #### Activate behavior to require all fields have a validation tag by default
 `SetFieldsRequiredByDefault` causes validation to fail when struct fields do not include validations or are not explicitly marked as exempt (using `valid:"-"` or `valid:"email,optional"`). A good place to activate this is a package init function or the main() function.
+
+`SetNilPtrAllowedByRequired` causes validation to pass when struct fields marked by `required` are set to nil. This is disabled by default for consistency, but some packages that need to be able to determine between `nil` and `zero value` state can use this. If disabled, both `nil` and `zero` values cause validation errors.
 
 ```go
 import "github.com/asaskevich/govalidator"

--- a/types.go
+++ b/types.go
@@ -3,6 +3,7 @@ package govalidator
 import (
 	"reflect"
 	"regexp"
+	"sort"
 	"sync"
 )
 
@@ -15,7 +16,26 @@ type CustomTypeValidator func(i interface{}, o interface{}) bool
 
 // ParamValidator is a wrapper for validator functions that accepts additional parameters.
 type ParamValidator func(str string, params ...string) bool
-type tagOptionsMap map[string]string
+type tagOptionsMap map[string]tagOption
+
+func (t tagOptionsMap) orderedKeys() []string {
+	var keys []string
+	for k := range t {
+		keys = append(keys, k)
+	}
+
+	sort.Slice(keys, func(a, b int) bool {
+		return t[keys[a]].order < t[keys[b]].order
+	})
+
+	return keys
+}
+
+type tagOption struct {
+	name               string
+	customErrorMessage string
+	order              int
+}
 
 // UnsupportedTypeError is a wrapper for reflect.Type
 type UnsupportedTypeError struct {

--- a/utils.go
+++ b/utils.go
@@ -262,3 +262,9 @@ func buildPadStr(str string, padStr string, padLen int, padLeft bool, padRight b
 
 	return leftSide + str + rightSide
 }
+
+// TruncatingErrorf removes extra args from fmt.Errorf if not formatted in the str object
+func TruncatingErrorf(str string, args ...interface{}) error {
+	n := strings.Count(str, "%s")
+	return fmt.Errorf(str, args[:n]...)
+}


### PR DESCRIPTION
Hey, I've fixed a bunch of issues that were bugging me:

1) Validation order is now enforced by the order of your tags. I had tests that were failing occasionally due to the fact that go randomises the order you iterate over maps, meaning the validation errors returned were different from run to run.

2) You can now use "%s %s" in your custom error messages to get the input data and validation rule that failed. This allows you to have customErrorMessages that contain the input data.

3) Slightly more controversial, so I've made it configurable to keep backwards compatibility. We need the ability to treat nil pointer values differently from zero values. If a field is a pointer and it is set to nil, it should pass `required` field checks as if it was required, it wouldn't be a pointer (the controversial bit). If a field is set to it's zero value, it will still be treated as required.

Feel free to make alterations as you see fit.