### PR TITLE
Validate the child struct when its an interface

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -725,8 +725,11 @@ func ValidateStruct(s interface{}) (bool, error) {
 			continue // Private field
 		}
 		structResult := true
-		if (valueField.Kind() == reflect.Struct || ((valueField.Kind() == reflect.Interface ||
-			valueField.Kind() == reflect.Ptr) && valueField.Elem().Kind() == reflect.Struct)) &&
+		if valueField.Kind() == reflect.Interface {
+			valueField = valueField.Elem()
+		}
+		if (valueField.Kind() == reflect.Struct ||
+			(valueField.Kind() == reflect.Ptr && valueField.Elem().Kind() == reflect.Struct)) &&
 			typeField.Tag.Get(tagName) != "-" {
 			var err error
 			structResult, err = ValidateStruct(valueField.Interface())

--- a/validator.go
+++ b/validator.go
@@ -725,8 +725,8 @@ func ValidateStruct(s interface{}) (bool, error) {
 			continue // Private field
 		}
 		structResult := true
-		if (valueField.Kind() == reflect.Struct ||
-			(valueField.Kind() == reflect.Ptr && valueField.Elem().Kind() == reflect.Struct)) &&
+		if (valueField.Kind() == reflect.Struct || ((valueField.Kind() == reflect.Interface ||
+			valueField.Kind() == reflect.Ptr) && valueField.Elem().Kind() == reflect.Struct)) &&
 			typeField.Tag.Get(tagName) != "-" {
 			var err error
 			structResult, err = ValidateStruct(valueField.Interface())


### PR DESCRIPTION
This PR validates the inner struct when its passed onto a field that is defined as an interface. The current implementation only checks for child structs that are pointers.