### PR TITLE
Add go fmt as a CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,5 +6,6 @@ jobs:
     working_directory: /go/src/github.com/asaskevich/govalidator
     steps:
       - checkout
+      - run: diff -u /dev/null <(gofmt -d .)
       - run: go get -v -t -d ./...
       - run: go test -v ./...


### PR DESCRIPTION
`go fmt` doesn't change it's exit code when it finds formatting violations, so we need to diff it's output with "nothing".