### PR TITLE
Fix TestIsExistingEmail()

### DIFF
--- a/validator_test.go
+++ b/validator_test.go
@@ -645,7 +645,7 @@ func TestIsExistingEmail(t *testing.T) {
 		{"foo@bar.com", true},
 		{"foo@bar.com.au", true},
 		{"foo+bar@bar.com", true},
-		{"foo@bar.coffee", true},
+		{"foo@driftaway.coffee", true},
 		{"foo@bar.coffee..coffee", false},
 		{"invalidemail@", false},
 		{"invalid.com", false},


### PR DESCRIPTION
The test uses `bar.coffee` domain which doesn't exist and cannot be resolved. Let's replace it with `driftaway.coffee`.