### PR TITLE
Validate empty values

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -323,12 +323,12 @@ func IsNull(str string) bool {
 
 // HasWhitespaceOnly checks the string only contains whitespace
 func HasWhitespaceOnly(str string) bool {
-    return len(str) > 0 && rxHasWhitespaceOnly.MatchString(str)
+	return len(str) > 0 && rxHasWhitespaceOnly.MatchString(str)
 }
 
 // HasWhitespace checks if the string contains any whitespace
 func HasWhitespace(str string) bool {
-    return len(str) > 0 && rxHasWhitespace.MatchString(str)
+	return len(str) > 0 && rxHasWhitespace.MatchString(str)
 }
 
 // IsByteLength check if the string's length (in bytes) falls in a range.
@@ -1121,10 +1121,10 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 				delete(options, validatorSpec)
 
 				switch v.Kind() {
-                case reflect.String,
-                    reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-                    reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
-                    reflect.Float32, reflect.Float64:
+				case reflect.String,
+					reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+					reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+					reflect.Float32, reflect.Float64:
 					field := fmt.Sprint(v) // make value into string, then validate with regex
 					if result := validatefunc(field); !result && !negate || result && negate {
 						if customMsgExists {

--- a/validator.go
+++ b/validator.go
@@ -1014,7 +1014,7 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 		options = parseTagIntoMap(tag)
 	}
 
-	if isEmptyValue(v) {
+	if !isFieldSet(v) {
 		// an empty value is not validated, check only required
 		isValid, resultErr = checkRequired(v, t, options)
 		for key := range options {
@@ -1212,25 +1212,14 @@ func stripParams(validatorString string) string {
 	return paramsRegexp.ReplaceAllString(validatorString, "")
 }
 
-func isEmptyValue(v reflect.Value) bool {
+// isFieldSet returns false for nil pointers, interfaces, maps, and slices. For all other values, it returns true.
+func isFieldSet(v reflect.Value) bool {
 	switch v.Kind() {
-	case reflect.String, reflect.Array:
-		return v.Len() == 0
-	case reflect.Map, reflect.Slice:
-		return v.Len() == 0 || v.IsNil()
-	case reflect.Bool:
-		return !v.Bool()
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return v.Int() == 0
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return v.Uint() == 0
-	case reflect.Float32, reflect.Float64:
-		return v.Float() == 0
-	case reflect.Interface, reflect.Ptr:
-		return v.IsNil()
+	case reflect.Map, reflect.Slice, reflect.Interface, reflect.Ptr:
+		return !v.IsNil()
 	}
 
-	return reflect.DeepEqual(v.Interface(), reflect.Zero(v.Type()).Interface())
+	return true
 }
 
 // ErrorByField returns error for specified field of the struct

--- a/validator_test.go
+++ b/validator_test.go
@@ -2199,7 +2199,7 @@ type User struct {
 	Name     string `valid:"required"`
 	Email    string `valid:"required,email"`
 	Password string `valid:"required"`
-	Age      int    `valid:"required,numeric,@#\u0000"`
+	Age      int    `valid:"required,numeric,range(1|200),@#\u0000"`
 	Home     *Address
 	Work     []Address
 }
@@ -2249,6 +2249,10 @@ type IsInStruct struct {
 	IsIn string `valid:"in(PRESENT|PRÉSENTE|NOTABSENT)"`
 }
 
+type IsInStructWithPointer struct {
+	IsIn *string `valid:"in(PRESENT|PRÉSENTE|NOTABSENT)"`
+}
+
 type Post struct {
 	Title    string `valid:"alpha,required"`
 	Message  string `valid:"ascii"`
@@ -2277,6 +2281,11 @@ type FieldsRequiredByDefaultButExemptStruct struct {
 type FieldsRequiredByDefaultButExemptOrOptionalStruct struct {
 	Name  string `valid:"-"`
 	Email string `valid:"optional,email"`
+}
+
+type FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers struct {
+	Name  *string `valid:"-"`
+	Email *string `valid:"optional,email"`
 }
 
 type MessageWithSeveralFieldsStruct struct {
@@ -2373,9 +2382,9 @@ func TestFieldsRequiredByDefaultButExemptOrOptionalStruct(t *testing.T) {
 		param    FieldsRequiredByDefaultButExemptOrOptionalStruct
 		expected bool
 	}{
-		{FieldsRequiredByDefaultButExemptOrOptionalStruct{}, true},
-		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Name: "TEST"}, true},
-		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Email: ""}, true},
+		{FieldsRequiredByDefaultButExemptOrOptionalStruct{}, false},
+		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Name: "TEST"}, false},
+		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Email: ""}, false},
 		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Email: "test@example.com"}, true},
 		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Email: "test@example"}, false},
 	}
@@ -2386,6 +2395,31 @@ func TestFieldsRequiredByDefaultButExemptOrOptionalStruct(t *testing.T) {
 			t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
 			if err != nil {
 				t.Errorf("Got Error on ValidateStruct(%q): %s", test.param, err)
+			}
+		}
+	}
+	SetFieldsRequiredByDefault(false)
+}
+
+func TestFieldsRequiredByDefaultButExemptOrOptionalStructWithPointers(t *testing.T) {
+	var tests = []struct {
+		param    FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers
+		expected bool
+	}{
+		{FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers{}, true},
+		{FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers{Name: ptrString("TEST")}, true},
+		{FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers{Email: ptrString("")}, false},
+		{FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers{Email: nil}, true},
+		{FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers{Email: ptrString("test@example.com")}, true},
+		{FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers{Email: ptrString("test@example")}, false},
+	}
+	SetFieldsRequiredByDefault(true)
+	for _, test := range tests {
+		actual, err := ValidateStruct(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected ValidateStruct(%#v) to be %v, got %v", test.param, test.expected, actual)
+			if err != nil {
+				t.Errorf("Got Error on ValidateStruct(%#v): %s", test.param, err)
 			}
 		}
 	}
@@ -2414,7 +2448,7 @@ func TestCustomValidator(t *testing.T) {
 	}
 
 	type StructWithCustomAndBuiltinValidator struct {
-		Field int `valid:"customTrueValidator,required"`
+		Field *int `valid:"customTrueValidator,required"`
 	}
 
 	if valid, err := ValidateStruct(&ValidStruct{Field: 1}); !valid || err != nil {
@@ -2431,7 +2465,7 @@ func TestCustomValidator(t *testing.T) {
 		t.Errorf("Got an unexpected result for invalid struct with custom and built-in validators: %t %s", valid, err)
 	}
 
-	mixedStruct.Field = 1
+	mixedStruct.Field = ptrInt(1)
 	if valid, err := ValidateStruct(&mixedStruct); !valid || err != nil {
 		t.Errorf("Got an unexpected result for valid struct with custom and built-in validators: %t %s", valid, err)
 	}
@@ -2599,9 +2633,13 @@ func TestIsInStruct(t *testing.T) {
 		expected bool
 	}{
 		{IsInStruct{"PRESENT"}, true},
-		{IsInStruct{""}, true},
+		{IsInStruct{""}, false},
 		{IsInStruct{" "}, false},
 		{IsInStruct{"ABSENT"}, false},
+		{IsInStructWithPointer{ptrString("PRESENT")}, true},
+		{IsInStructWithPointer{nil}, true},
+		{IsInStructWithPointer{ptrString("")}, false},
+		{IsInStructWithPointer{ptrString("ABSENT")}, false},
 	}
 
 	for _, test := range tests {
@@ -2619,6 +2657,9 @@ func TestRequiredIsInStruct(t *testing.T) {
 	type RequiredIsInStruct struct {
 		IsIn string `valid:"in(PRESENT|PRÉSENTE|NOTABSENT),required"`
 	}
+	type RequiredIsInStructWithPointer struct {
+		IsIn *string `valid:"in(PRESENT|PRÉSENTE|NOTABSENT),required"`
+	}
 
 	var tests = []struct {
 		param    interface{}
@@ -2628,6 +2669,10 @@ func TestRequiredIsInStruct(t *testing.T) {
 		{RequiredIsInStruct{""}, false},
 		{RequiredIsInStruct{" "}, false},
 		{RequiredIsInStruct{"ABSENT"}, false},
+		{RequiredIsInStructWithPointer{ptrString("PRESENT")}, true},
+		{RequiredIsInStructWithPointer{ptrString("")}, false},
+		{RequiredIsInStructWithPointer{nil}, false},
+		{RequiredIsInStructWithPointer{ptrString("ABSENT")}, false},
 	}
 
 	for _, test := range tests {
@@ -2645,15 +2690,21 @@ func TestEmptyRequiredIsInStruct(t *testing.T) {
 	type EmptyRequiredIsInStruct struct {
 		IsIn string `valid:"in(),required"`
 	}
+	type EmptyRequiredIsInStructWithPointer struct {
+		IsIn *string `valid:"in(),required"`
+	}
 
 	var tests = []struct {
 		param    interface{}
 		expected bool
 	}{
 		{EmptyRequiredIsInStruct{"PRESENT"}, false},
-		{EmptyRequiredIsInStruct{""}, false},
+		{EmptyRequiredIsInStruct{""}, true}, // an empty string is allowed by 'in()' !
 		{EmptyRequiredIsInStruct{" "}, false},
 		{EmptyRequiredIsInStruct{"ABSENT"}, false},
+		{EmptyRequiredIsInStructWithPointer{ptrString("PRESENT")}, false},
+		{EmptyRequiredIsInStructWithPointer{ptrString("")}, true},
+		{EmptyRequiredIsInStructWithPointer{nil}, false},
 	}
 
 	for _, test := range tests {
@@ -2681,8 +2732,8 @@ func TestEmptyStringPtr(t *testing.T) {
 		expected    bool
 		expectedErr string
 	}{
-		{EmptyIsInStruct{&empty}, false, "IsIn: non zero value required"},
-		{EmptyIsInStruct{nil}, true, ""},
+		{EmptyIsInStruct{&empty}, false, "IsIn:  does not validate as length(3|5)"},
+		{EmptyIsInStruct{nil}, true, ""}, // because of SetNilPtrAllowedByRequired(true)
 		{EmptyIsInStruct{&valid}, true, ""},
 		{EmptyIsInStruct{&invalid}, false, "IsIn: 123456 does not validate as length(3|5)"},
 	}
@@ -2692,14 +2743,14 @@ func TestEmptyStringPtr(t *testing.T) {
 		actual, err := ValidateStruct(test.param)
 
 		if actual != test.expected {
-			t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
+			t.Errorf("Expected ValidateStruct(%#v) to be %v, got %v", test.param, test.expected, actual)
 		}
 		if err != nil {
 			if err.Error() != test.expectedErr {
-				t.Errorf("Got Error on ValidateStruct(%q). Expected: %s Actual: %s", test.param, test.expectedErr, err)
+				t.Errorf("Got Error on ValidateStruct(%#v). Expected: %s Actual: %s", test.param, test.expectedErr, err)
 			}
 		} else if test.expectedErr != "" {
-			t.Errorf("Expected error on ValidateStruct(%q).", test.param)
+			t.Errorf("Expected error on ValidateStruct(%#v).", test.param)
 		}
 	}
 	SetNilPtrAllowedByRequired(false)
@@ -2728,17 +2779,17 @@ func TestNestedStruct(t *testing.T) {
 			Nested: NestedStruct{
 				Foo: "",
 			},
-		}, false, "Nested.Foo: non zero value required"},
+		}, false, "Nested.Foo:  does not validate as length(3|5);Nested.EvenMoreNested.Bar:  does not validate as length(3|5)"},
 		{OuterStruct{
 			Nested: NestedStruct{
 				Foo: "123",
 			},
-		}, true, ""},
+		}, false, "Nested.EvenMoreNested.Bar:  does not validate as length(3|5)"},
 		{OuterStruct{
 			Nested: NestedStruct{
 				Foo: "123456",
 			},
-		}, false, "Nested.Foo: 123456 does not validate as length(3|5)"},
+		}, false, "Nested.Foo: 123456 does not validate as length(3|5);Nested.EvenMoreNested.Bar:  does not validate as length(3|5)"},
 		{OuterStruct{
 			Nested: NestedStruct{
 				Foo: "123",
@@ -2756,7 +2807,7 @@ func TestNestedStruct(t *testing.T) {
 					},
 				},
 			},
-		}, false, "Nested.SliceEvenMoreNested.0.Bar: 123456 does not validate as length(3|5)"},
+		}, false, "Nested.EvenMoreNested.Bar:  does not validate as length(3|5);Nested.SliceEvenMoreNested.0.Bar: 123456 does not validate as length(3|5)"},
 		{OuterStruct{
 			Nested: NestedStruct{
 				Foo: "123",
@@ -2766,7 +2817,7 @@ func TestNestedStruct(t *testing.T) {
 					},
 				},
 			},
-		}, false, "Nested.MapEvenMoreNested.Foo.Bar: 123456 does not validate as length(3|5)"},
+		}, false, "Nested.EvenMoreNested.Bar:  does not validate as length(3|5);Nested.MapEvenMoreNested.Foo.Bar: 123456 does not validate as length(3|5)"},
 	}
 
 	for _, test := range tests {
@@ -2842,7 +2893,7 @@ func TestValidateStruct(t *testing.T) {
 		param    interface{}
 		expected bool
 	}{
-		{User{"John", "john@yahoo.com", "123G#678", 20, &Address{"Street", "ABC456D89"},    []Address{{"Street", "123456"}, {"Street", "123456"}}}, false},
+		{User{"John", "john@yahoo.com", "123G#678", 20, &Address{"Street", "ABC456D89"}, []Address{{"Street", "123456"}, {"Street", "123456"}}}, false},
 		{User{"John", "john!yahoo.com", "12345678", 20, &Address{"Street", "ABC456D89"}, []Address{{"Street", "ABC456D89"}, {"Street", "123456"}}}, false},
 		{User{"John", "", "12345", 0, &Address{"Street", "123456789"}, []Address{{"Street", "ABC456D89"}, {"Street", "123456"}}}, false},
 		{UserValid{"John", "john@yahoo.com", "123G#678", 20, &Address{"Street", "123456"}, []Address{{"Street", "123456"}, {"Street", "123456"}}}, true},
@@ -2857,9 +2908,9 @@ func TestValidateStruct(t *testing.T) {
 	for _, test := range tests {
 		actual, err := ValidateStruct(test.param)
 		if actual != test.expected {
-			t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
+			t.Errorf("Expected ValidateStruct(%#v) to be %v, got %v", test.param, test.expected, actual)
 			if err != nil {
-				t.Errorf("Got Error on ValidateStruct(%q): %s", test.param, err)
+				t.Errorf("Got Error on ValidateStruct(%#v): %s", test.param, err)
 			}
 		}
 	}
@@ -2902,7 +2953,7 @@ func TestRequired(t *testing.T) {
 			}{
 				Pointer: &testEmptyString,
 			},
-			false,
+			true,
 		},
 		{
 			struct {
@@ -2916,7 +2967,7 @@ func TestRequired(t *testing.T) {
 			struct {
 				Addr Address `valid:"required"`
 			}{},
-			false,
+			true,
 		},
 		{
 			struct {
@@ -2943,16 +2994,10 @@ func TestRequired(t *testing.T) {
 		{
 			struct {
 				TestByteArray testByteArray `valid:"required"`
-			}{},
-			false,
-		},
-		{
-			struct {
-				TestByteArray testByteArray `valid:"required"`
 			}{
 				testByteArray{},
 			},
-			false,
+			true, // array cannot be nil
 		},
 		{
 			struct {
@@ -2994,9 +3039,9 @@ func TestRequired(t *testing.T) {
 	for _, test := range tests {
 		actual, err := ValidateStruct(test.param)
 		if actual != test.expected {
-			t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
+			t.Errorf("Expected ValidateStruct(%#v) to be %v, got %v", test.param, test.expected, actual)
 			if err != nil {
-				t.Errorf("Got Error on ValidateStruct(%q): %s", test.param, err)
+				t.Errorf("Got Error on ValidateStruct(%#v): %s", test.param, err)
 			}
 		}
 	}
@@ -3338,6 +3383,29 @@ func TestOptionalCustomValidators(t *testing.T) {
 
 	ok, err := ValidateStruct(val)
 
+	if err == nil {
+		t.Error("Expected non-nil err with optional validation, got nil")
+	}
+
+	if ok {
+		t.Error("Expected validation to return false, got true")
+	}
+}
+
+func TestOptionalCustomValidatorsWithPointers(t *testing.T) {
+
+	CustomTypeTagMap.Set("f2", CustomTypeValidator(func(i interface{}, o interface{}) bool {
+		return false
+	}))
+
+	var val struct {
+		WithCustomError    *string `valid:"f2~boom,optional"`
+		WithoutCustomError *string `valid:"f2,optional"`
+		OptionalFirst      *string `valid:"optional,f2"`
+	}
+
+	ok, err := ValidateStruct(val)
+
 	if err != nil {
 		t.Errorf("Expected nil err with optional validation, got %v", err)
 	}
@@ -3488,3 +3556,6 @@ bQIDAQAB
 		}
 	}
 }
+
+func ptrString(s string) *string { return &s }
+func ptrInt(i int) *int          { return &i }

--- a/validator_test.go
+++ b/validator_test.go
@@ -1020,53 +1020,53 @@ func TestIsNull(t *testing.T) {
 }
 
 func TestHasWhitespaceOnly(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    var tests = []struct {
-        param    string
-        expected bool
-    }{
-        {"abacaba", false},
-        {"", false},
-        {"    ", true},
-        {"  \r\n  ", true},
-        {"\014\012\011\013\015", true},
-        {"\014\012\011\013 abc  \015", false},
-        {"\f\n\t\v\r\f", true},
-        {"x\n\t\t\t\t", false},
-        {"\f\n\t  \n\n\n   \v\r\f", true},
-    }
-    for _, test := range tests {
-        actual := HasWhitespaceOnly(test.param)
-        if actual != test.expected {
-            t.Errorf("Expected HasWhitespaceOnly(%q) to be %v, got %v", test.param, test.expected, actual)
-        }
-    }
+	var tests = []struct {
+		param    string
+		expected bool
+	}{
+		{"abacaba", false},
+		{"", false},
+		{"    ", true},
+		{"  \r\n  ", true},
+		{"\014\012\011\013\015", true},
+		{"\014\012\011\013 abc  \015", false},
+		{"\f\n\t\v\r\f", true},
+		{"x\n\t\t\t\t", false},
+		{"\f\n\t  \n\n\n   \v\r\f", true},
+	}
+	for _, test := range tests {
+		actual := HasWhitespaceOnly(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected HasWhitespaceOnly(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+	}
 }
 
 func TestHasWhitespace(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    var tests = []struct {
-        param    string
-        expected bool
-    }{
-        {"abacaba", false},
-        {"", false},
-        {"    ", true},
-        {"  \r\n  ", true},
-        {"\014\012\011\013\015", true},
-        {"\014\012\011\013 abc  \015", true},
-        {"\f\n\t\v\r\f", true},
-        {"x\n\t\t\t\t", true},
-        {"\f\n\t  \n\n\n   \v\r\f", true},
-    }
-    for _, test := range tests {
-        actual := HasWhitespace(test.param)
-        if actual != test.expected {
-            t.Errorf("Expected HasWhitespace(%q) to be %v, got %v", test.param, test.expected, actual)
-        }
-    }
+	var tests = []struct {
+		param    string
+		expected bool
+	}{
+		{"abacaba", false},
+		{"", false},
+		{"    ", true},
+		{"  \r\n  ", true},
+		{"\014\012\011\013\015", true},
+		{"\014\012\011\013 abc  \015", true},
+		{"\f\n\t\v\r\f", true},
+		{"x\n\t\t\t\t", true},
+		{"\f\n\t  \n\n\n   \v\r\f", true},
+	}
+	for _, test := range tests {
+		actual := HasWhitespace(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected HasWhitespace(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+	}
 }
 
 func TestIsDivisibleBy(t *testing.T) {
@@ -3284,67 +3284,67 @@ func TestValidateStructParamValidatorInt(t *testing.T) {
 	if err == nil {
 		t.Errorf("Test failed: nil")
 	}
-	
+
 	type Test3 struct {
-        Int   int   `valid:"in(1|10),int"`
-        Int8  int8  `valid:"in(1|10),int8"`
-        Int16 int16 `valid:"in(1|10),int16"`
-        Int32 int32 `valid:"in(1|10),int32"`
-        Int64 int64 `valid:"in(1|10),int64"`
+		Int   int   `valid:"in(1|10),int"`
+		Int8  int8  `valid:"in(1|10),int8"`
+		Int16 int16 `valid:"in(1|10),int16"`
+		Int32 int32 `valid:"in(1|10),int32"`
+		Int64 int64 `valid:"in(1|10),int64"`
 
-        Uint   uint   `valid:"in(1|10),uint"`
-        Uint8  uint8  `valid:"in(1|10),uint8"`
-        Uint16 uint16 `valid:"in(1|10),uint16"`
-        Uint32 uint32 `valid:"in(1|10),uint32"`
-        Uint64 uint64 `valid:"in(1|10),uint64"`
+		Uint   uint   `valid:"in(1|10),uint"`
+		Uint8  uint8  `valid:"in(1|10),uint8"`
+		Uint16 uint16 `valid:"in(1|10),uint16"`
+		Uint32 uint32 `valid:"in(1|10),uint32"`
+		Uint64 uint64 `valid:"in(1|10),uint64"`
 
-        Float32 float32 `valid:"in(1|10),float32"`
-        Float64 float64 `valid:"in(1|10),float64"`
-    }
+		Float32 float32 `valid:"in(1|10),float32"`
+		Float64 float64 `valid:"in(1|10),float64"`
+	}
 
-    test3Ok1 := &Test2{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
-    test3Ok2 := &Test2{10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10}
-    test3NotOk := &Test2{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2}
+	test3Ok1 := &Test2{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	test3Ok2 := &Test2{10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10}
+	test3NotOk := &Test2{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2}
 
-    _, err = ValidateStruct(test3Ok1)
-    if err != nil {
-        t.Errorf("Test failed: %s", err)
-    }
+	_, err = ValidateStruct(test3Ok1)
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
 
-    _, err = ValidateStruct(test3Ok2)
-    if err != nil {
-        t.Errorf("Test failed: %s", err)
-    }
+	_, err = ValidateStruct(test3Ok2)
+	if err != nil {
+		t.Errorf("Test failed: %s", err)
+	}
 
-    _, err = ValidateStruct(test3NotOk)
-    if err == nil {
-        t.Errorf("Test failed: nil")
-    }
+	_, err = ValidateStruct(test3NotOk)
+	if err == nil {
+		t.Errorf("Test failed: nil")
+	}
 }
 
 func TestValidateStructUpperAndLowerCaseWithNumTypeCheck(t *testing.T) {
 
-    type StructCapital struct {
-        Total float32 `valid:"float,required"`
-    }
-    
-    structCapital := &StructCapital{53.3535}
-    _, err := ValidateStruct(structCapital)
-    if err != nil {
-        t.Errorf("Test failed: nil")
-        fmt.Println(err)
-    }
-    
-    type StructLower struct {
-        total float32 `valid:"float,required"`
-    }
-    
-    structLower := &StructLower{53.3535}
-    _, err = ValidateStruct(structLower)
-    if err != nil {
-        t.Errorf("Test failed: nil")
-        fmt.Println(err)
-    }
+	type StructCapital struct {
+		Total float32 `valid:"float,required"`
+	}
+
+	structCapital := &StructCapital{53.3535}
+	_, err := ValidateStruct(structCapital)
+	if err != nil {
+		t.Errorf("Test failed: nil")
+		fmt.Println(err)
+	}
+
+	type StructLower struct {
+		total float32 `valid:"float,required"`
+	}
+
+	structLower := &StructLower{53.3535}
+	_, err = ValidateStruct(structLower)
+	if err != nil {
+		t.Errorf("Test failed: nil")
+		fmt.Println(err)
+	}
 }
 
 func TestIsCIDR(t *testing.T) {


### PR DESCRIPTION
Currently `govalidator` skips validation of zero numbers, empty strings, and other zero values of any type. It treats them as always valid. On the other hand, `govalidator` errs when a 'required' field has a zero value which disallows entering zero values into required fields.

The goal of this PR is to solve both problems: to validate zero values and to allow 'required' fields to have zero/empty values.

The main idea is to skip validation only when we are sure that a value is a nil-value (we can distinguish nil values from zero/empty values only for pointers, interfaces, maps, and slices; we consider all other values as non-nil values). All non-nil values are being validated. The 'required` validator errs only for nil values.

If one wants to check that some required string or number is given, he/she can declare them as pointers:
```
type MyStruct struct {
   Name     *string `valid:"required"`
   Number *int       `valid:"required"`
}
```
This will fail when `Name` and/or `Number` are not given or equal to nil.

When one wants to disallow empty strings, it's still possible to use the `runelength` validator. And there is also the `range` validator for numeric values.

This PR fixes #276, #274, (probably) #260, #256, #246, (probably) #149, (probably) #136, #130.

