### PR TITLE
implement ValidateMap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ If you don't know what to do, there are some features and functions that need to
 - [ ] Update actual [list of functions](https://github.com/asaskevich/govalidator#list-of-functions)
 - [ ] Update [list of validators](https://github.com/asaskevich/govalidator#validatestruct-2) that available for `ValidateStruct` and add new
 - [ ] Implement new validators: `IsFQDN`, `IsIMEI`, `IsPostalCode`, `IsISIN`, `IsISRC` etc
-- [ ] Implement [validation by maps](https://github.com/asaskevich/govalidator/issues/224)
+- [x] Implement [validation by maps](https://github.com/asaskevich/govalidator/issues/224)
 - [ ] Implement fuzzing testing
 - [ ] Implement some struct/map/array utilities
 - [ ] Implement map/array validation

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ func IsRequestURL(rawurl string) bool
 func IsSSN(str string) bool
 func IsSemver(str string) bool
 func IsTime(str string, format string) bool
+func IsType(in interface{}, params ...string) bool
 func IsURL(str string) bool
 func IsUTFDigit(str string) bool
 func IsUTFLetter(str string) bool
@@ -227,6 +228,27 @@ type Validator
 ###### IsURL
 ```go
 println(govalidator.IsURL(`http://user@pass:domain.com/path/page`))
+```
+###### IsType
+```go
+println(govalidator.IsType("Bob", "string"))
+println(govalidator.IsType(1, "int"))
+i := 1
+println(govalidator.IsType(&i, "*int"))
+```
+
+IsType can be used through the tag `type` which is essential for map validation:
+```go
+type User	struct {
+  Name string      `valid:"type(string)"`
+  Age  int         `valid:"type(int)"`
+  Meta interface{} `valid:"type(string)"`
+}
+result, err := govalidator.ValidateStruct(user{"Bob", 20, "meta"})
+if err != nil {
+	println("error: " + err.Error())
+}
+println(result)
 ```
 ###### ToString
 ```go
@@ -335,6 +357,11 @@ Validators with parameters
 "matches(pattern)": StringMatches,
 "in(string1|string2|...|stringN)": IsIn,
 "rsapub(keylength)" : IsRsaPub,
+```
+Validators with parameters for any type
+
+```go
+"type(type)": IsType,
 ```
 
 And here is small example of usage:

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ func ToString(obj interface{}) string
 func Trim(str, chars string) string
 func Truncate(str string, length int, ending string) string
 func UnderscoreToCamelCase(s string) string
+func ValidateMap(s map[string]interface{}, o map[string]interface{}) (bool, error)
 func ValidateStruct(s interface{}) (bool, error)
 func WhiteList(str, chars string) string
 type ConditionIterator
@@ -370,6 +371,41 @@ if err != nil {
 }
 println(result)
 ```
+###### ValidateMap [#2](https://github.com/asaskevich/govalidator/pull/338)
+If you want to validate maps, you can use the map to be validated and a validation map that contain the same tags used in ValidateStruct, both maps have to be in the form `map[string]interface{}`
+
+So here is small example of usage:
+```go
+var mapTemplate = map[string]interface{}{
+	"name":"required,alpha",
+	"family":"required,alpha",
+	"email":"required,email",
+	"cell-phone":"numeric",
+	"address":map[string]interface{}{
+		"line1":"required,alphanum",
+		"line2":"alphanum",
+		"postal-code":"numeric",
+	},
+}
+
+var inputMap = map[string]interface{}{
+	"name":"Bob",
+	"family":"Smith",
+	"email":"foo@bar.baz",
+	"address":map[string]interface{}{
+		"line1":"",
+		"line2":"",
+		"postal-code":"",
+	},
+}
+
+result, err := govalidator.ValidateMap(mapTemplate, inputMap)
+if err != nil {
+	println("error: " + err.Error())
+}
+println(result)
+```
+
 ###### WhiteList
 ```go
 // Remove all characters from string ignoring characters between "a" and "z"
@@ -445,7 +481,7 @@ If you don't know what to do, there are some features and functions that need to
 - [ ] Update actual [list of functions](https://github.com/asaskevich/govalidator#list-of-functions)
 - [ ] Update [list of validators](https://github.com/asaskevich/govalidator#validatestruct-2) that available for `ValidateStruct` and add new
 - [ ] Implement new validators: `IsFQDN`, `IsIMEI`, `IsPostalCode`, `IsISIN`, `IsISRC` etc
-- [ ] Implement [validation by maps](https://github.com/asaskevich/govalidator/issues/224)
+- [x] Implement [validation by maps](https://github.com/asaskevich/govalidator/issues/224)
 - [ ] Implement fuzzing testing
 - [ ] Implement some struct/map/array utilities
 - [ ] Implement map/array validation

--- a/types.go
+++ b/types.go
@@ -16,6 +16,7 @@ type CustomTypeValidator func(i interface{}, o interface{}) bool
 
 // ParamValidator is a wrapper for validator functions that accepts additional parameters.
 type ParamValidator func(str string, params ...string) bool
+type InterfaceParamValidator func(in interface{}, params ...string) bool
 type tagOptionsMap map[string]tagOption
 
 func (t tagOptionsMap) orderedKeys() []string {
@@ -45,6 +46,16 @@ type UnsupportedTypeError struct {
 // stringValues is a slice of reflect.Value holding *reflect.StringValue.
 // It implements the methods to sort by string.
 type stringValues []reflect.Value
+
+// InterfaceParamTagMap is a map of functions accept variants parameters for an interface value
+var InterfaceParamTagMap = map[string]InterfaceParamValidator{
+	"type": IsType,
+}
+
+// InterfaceParamTagRegexMap maps interface param tags to their respective regexes.
+var InterfaceParamTagRegexMap = map[string]*regexp.Regexp{
+	"type": regexp.MustCompile(`^type\((.*)\)$`),
+}
 
 // ParamTagMap is a map of functions accept variants parameters
 var ParamTagMap = map[string]ParamValidator{

--- a/validator.go
+++ b/validator.go
@@ -800,6 +800,8 @@ func ValidateMap(s map[string]interface{}, m map[string]interface{}) (bool, erro
 			if err != nil {
 				errs = append(errs, err)
 			}
+		case nil:
+			// already handlerd when checked before
 		default:
 			typeResult = false
 			err = fmt.Errorf("map validator has to be either map[string]interface{} or string; got %s", valueField.Type().String())

--- a/validator_test.go
+++ b/validator_test.go
@@ -3950,6 +3950,52 @@ func TestValidateMapMissing(t *testing.T) {
 	}
 }
 
+func TestValidateMapMissingValidator(t *testing.T) {
+	t.Parallel()
+	var tests = []struct {
+		params    map[string]interface{}
+		validator map[string]interface{}
+		expected  bool
+	}{
+		{
+			map[string]interface{}{
+				"name":   "Bob",
+				"family": "Smith",
+			},
+			map[string]interface{}{
+				"name": "required,alpha",
+			},
+			false,
+		},
+		{
+			map[string]interface{}{
+				"name": "Bob",
+				"submap": map[string]interface{}{
+					"name":   "Bob",
+					"family": "Smith",
+				},
+			},
+			map[string]interface{}{
+				"name": "required,alpha",
+				"submap": map[string]interface{}{
+					"family": "required,alpha",
+				},
+			},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		actual, err := ValidateMap(test.params, test.validator)
+		if actual != test.expected {
+			t.Errorf("Expected ValidateMap(%q, %q) to be %v, got %v", test.params, test.validator, test.expected, actual)
+			if err != nil {
+				t.Errorf("Got Error on ValidateMap(%q, %q): %s", test.params, test.validator, err)
+			}
+		}
+	}
+}
+
 func TestIsType(t *testing.T) {
 	t.Parallel()
 	i := 1

--- a/validator_test.go
+++ b/validator_test.go
@@ -3904,6 +3904,52 @@ func TestValidateMap(t *testing.T) {
 	}
 }
 
+func TestValidateMapMissing(t *testing.T) {
+	t.Parallel()
+	var tests = []struct {
+		params    map[string]interface{}
+		validator map[string]interface{}
+		expected  bool
+	}{
+		{
+			map[string]interface{}{
+				"name": "Bob",
+			},
+			map[string]interface{}{
+				"name":   "required,alpha",
+				"family": "required,alpha",
+			},
+			false,
+		},
+		{
+			map[string]interface{}{
+				"name": "Bob",
+				"submap": map[string]interface{}{
+					"family": "Smith",
+				},
+			},
+			map[string]interface{}{
+				"name": "required,alpha",
+				"submap": map[string]interface{}{
+					"name":   "required,alpha",
+					"family": "required,alpha",
+				},
+			},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		actual, err := ValidateMap(test.params, test.validator)
+		if actual != test.expected {
+			t.Errorf("Expected ValidateMap(%q, %q) to be %v, got %v", test.params, test.validator, test.expected, actual)
+			if err != nil {
+				t.Errorf("Got Error on ValidateMap(%q, %q): %s", test.params, test.validator, err)
+			}
+		}
+	}
+}
+
 func TestIsType(t *testing.T) {
 	t.Parallel()
 	i := 1


### PR DESCRIPTION
Adds `ValidateMap` which can be used to validate `map[string]interface{}` against a validation map in the form `map[string]interface{}`. The validation map values can be either a string in the same form as the tags used in structs (without the key `valid`) or a `map[string]interface{}` for recursive validation. The map to be validated can contain values of any kind.

Example usage added in the README (copied from #224)
```go
var mapTemplate = map[string]interface{}{
	"name":"required,alpha",
	"family":"required,alpha",
	"email":"required,email",
	"cell-phone":"numeric",
	"address":map[string]interface{}{
		"line1":"required,alphanum",
		"line2":"alphanum",
		"postal-code":"numeric",
	},
}
 var inputMap = map[string]interface{}{
	"name":"Bob",
	"family":"Smith",
	"email":"foo@bar.baz",
	"address":map[string]interface{}{
		"line1":"1234",
		"line2":"",
		"postal-code":"",
	},
}
 result, err := govalidator.ValidateMap(mapTemplate, inputMap)
if err != nil {
	println("error: " + err.Error())
}
println(result)
```

It also adds custom tag `type(type)` to validate map values of type `interface{}`. However, it can be used with any type. Example of types it can take:

```go
string
int
*int
**int
map[string]string
map[string]interface{}
[][]int
```

fixes #224
