### PR TITLE
Include the min and max string length checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ Validators with parameters
 "matches(pattern)": StringMatches,
 "in(string1|string2|...|stringN)": IsIn,
 "rsapub(keylength)" : IsRsaPub,
+"minstringlength(int): MinStringLength,
+"maxstringlength(int): MaxStringLength,
 ```
 Validators with parameters for any type
 


### PR DESCRIPTION
ParamTagMap already has `minstringlength` and `maxstringlength` but they are not included in the readme.
Seeing how all other possible tags with params are included, these should probably be included too.