### PR TITLE
Add test to verify behavior of required check on byte slice.

### DIFF
--- a/validator_test.go
+++ b/validator_test.go
@@ -3339,6 +3339,14 @@ func TestRequired(t *testing.T) {
 		},
 		{
 			struct {
+				TestByteSlice testByteSlice `valid:"required"`
+			}{
+				[]byte{93, 93, 0, 75},
+			},
+			true,
+		},
+		{
+			struct {
 				TestStringStringMap testStringStringMap `valid:"required"`
 			}{
 				testStringStringMap{"test": "test"},


### PR DESCRIPTION
## Description 

I went through the Issue list and wanted to see if I could contribute in a small way. Noticed Issue https://github.com/asaskevich/govalidator/issues/334 and decided to take a look.

Added a test case to the validator_test.go to cover the reported failure. Unable to reproduce given the same required value and input. At this point it may be assumed this behavior has been addressed in more recent updates. 

Adding test case to cover the behavior for the future.