### PR TITLE
Empty email to success when optional

### DIFF
--- a/validator_test.go
+++ b/validator_test.go
@@ -2495,7 +2495,7 @@ func TestFieldsRequiredByDefaultButExemptOrOptionalStruct(t *testing.T) {
 		expected bool
 	}{
 		{FieldsRequiredByDefaultButExemptOrOptionalStruct{}, true},
-		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Name: "TEST"}, false},
+		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Name: "TEST"}, true},
 		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Email: ""}, true},
 		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Email: "test@example.com"}, true},
 		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Email: "test@example"}, false},
@@ -2532,7 +2532,7 @@ func TestFieldsRequiredByDefaultButExemptOrOptionalStructWithPointers(t *testing
 	}{
 		{FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers{}, true},
 		{FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers{Name: ptrString("TEST")}, true},
-		{FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers{Email: ptrString("")}, false},
+		{FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers{Email: ptrString("")}, true},
 		{FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers{Email: nil}, true},
 		{FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers{Email: ptrString("test@example.com")}, true},
 		{FieldsRequiredByDefaultButExemptOrOptionalStructWithPointers{Email: ptrString("test@example")}, false},
@@ -2868,12 +2868,12 @@ func TestIsInStruct(t *testing.T) {
 		expected bool
 	}{
 		{IsInStruct{"PRESENT"}, true},
-		{IsInStruct{""}, false},
+		{IsInStruct{""}, true},
 		{IsInStruct{" "}, false},
 		{IsInStruct{"ABSENT"}, false},
 		{IsInStructWithPointer{ptrString("PRESENT")}, true},
 		{IsInStructWithPointer{nil}, true},
-		{IsInStructWithPointer{ptrString("")}, false},
+		{IsInStructWithPointer{ptrString("")}, true},
 		{IsInStructWithPointer{ptrString("ABSENT")}, false},
 	}
 
@@ -3067,17 +3067,17 @@ func TestNestedStruct(t *testing.T) {
 			Nested: NestedStruct{
 				Foo: "",
 			},
-		}, false, "Nested.EvenMoreNested.Bar:  does not validate as length(3|5);Nested.Foo:  does not validate as length(3|5)"},
+		}, false, "Nested.Foo:  does not validate as length(3|5)"},
 		{OuterStruct{
 			Nested: NestedStruct{
 				Foo: "123",
 			},
-		}, false, "Nested.EvenMoreNested.Bar:  does not validate as length(3|5)"},
+		}, true, ""},
 		{OuterStruct{
 			Nested: NestedStruct{
 				Foo: "123456",
 			},
-		}, false, "Nested.EvenMoreNested.Bar:  does not validate as length(3|5);Nested.Foo: 123456 does not validate as length(3|5)"},
+		}, false, "Nested.Foo: 123456 does not validate as length(3|5)"},
 		{OuterStruct{
 			Nested: NestedStruct{
 				Foo: "123",
@@ -3095,7 +3095,7 @@ func TestNestedStruct(t *testing.T) {
 					},
 				},
 			},
-		}, false, "Nested.EvenMoreNested.Bar:  does not validate as length(3|5);Nested.SliceEvenMoreNested.0.Bar: 123456 does not validate as length(3|5)"},
+		}, false, "Nested.SliceEvenMoreNested.0.Bar: 123456 does not validate as length(3|5)"},
 		{OuterStruct{
 			Nested: NestedStruct{
 				Foo: "123",
@@ -3105,7 +3105,7 @@ func TestNestedStruct(t *testing.T) {
 					},
 				},
 			},
-		}, false, "Nested.EvenMoreNested.Bar:  does not validate as length(3|5);Nested.MapEvenMoreNested.Foo.Bar: 123456 does not validate as length(3|5)"},
+		}, false, "Nested.MapEvenMoreNested.Foo.Bar: 123456 does not validate as length(3|5)"},
 	}
 
 	for _, test := range tests {
@@ -3760,12 +3760,12 @@ func TestOptionalCustomValidators(t *testing.T) {
 
 	ok, err := ValidateStruct(val)
 
-	if err == nil {
-		t.Error("Expected non-nil err with optional validation, got nil")
+	if err != nil {
+		t.Errorf("Expected nil err with optional validation, got %v", err)
 	}
 
-	if ok {
-		t.Error("Expected validation to return false, got true")
+	if !ok {
+		t.Error("Expected validation to return true, got false")
 	}
 }
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -2494,9 +2494,9 @@ func TestFieldsRequiredByDefaultButExemptOrOptionalStruct(t *testing.T) {
 		param    FieldsRequiredByDefaultButExemptOrOptionalStruct
 		expected bool
 	}{
-		{FieldsRequiredByDefaultButExemptOrOptionalStruct{}, false},
+		{FieldsRequiredByDefaultButExemptOrOptionalStruct{}, true},
 		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Name: "TEST"}, false},
-		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Email: ""}, false},
+		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Email: ""}, true},
 		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Email: "test@example.com"}, true},
 		{FieldsRequiredByDefaultButExemptOrOptionalStruct{Email: "test@example"}, false},
 	}


### PR DESCRIPTION
I fixed this issue https://github.com/asaskevich/govalidator/issues/368.

In PR https://github.com/asaskevich/govalidator/pull/329, 2 changes were made. 

(1) If the field is required, only nil value is treated as invalid and skips other validations.
(2) If the field is optional, nil value skip validations. The empty values doesn't skip validation.

Because of (2), below example is not working. A empty email become invalid.

```Go
// lastly, this will only fail when Email is an invalid email address but not when it's empty:
type exampleStruct2 struct {
  Name  string `valid:"-"`
  Email string `valid:"email,optional"`
}
```
So I made changes below.

(1) If the field is optional, nil and empty value is valid (skip other validation).
(2) If the field is required, only nil values is treated as invalid and skip other validation.

I'm not sure this is the best way to do it, but I hope you'll consider it.

(Maybe we should fix it so that only nil is treated as "zero value" when it is a pointer type)