### PR TITLE
Fix #351 selects an incorrect field name in the error message when nesting the structure.

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -24,6 +24,7 @@ import (
 
 var (
 	fieldsRequiredByDefault bool
+	jsonTag string
 	nilPtrAllowedByRequired = false
 	notNumberRegexp         = regexp.MustCompile("[^0-9]+")
 	whiteSpacesAndMinus     = regexp.MustCompile(`[\s-]+`)
@@ -1005,7 +1006,6 @@ func ValidateStruct(s interface{}) (bool, error) {
 		if err2 != nil {
 
 			// Replace structure name with JSON name if there is a tag on the variable
-			jsonTag := toJSONName(typeField.Tag.Get("json"))
 			if jsonTag != "" {
 				switch jsonError := err2.(type) {
 				case Error:
@@ -1302,6 +1302,7 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 		return false, nil
 	}
 
+	jsonTag = toJSONName(t.Tag.Get("json"))
 	tag := t.Tag.Get(tagName)
 
 	// checks if the field should be ignored

--- a/validator_test.go
+++ b/validator_test.go
@@ -3464,6 +3464,50 @@ func TestJSONValidator(t *testing.T) {
 	}
 }
 
+func TestNestedStructWithJson(t *testing.T) {
+	type Details struct {
+		Email string `json:"email" valid:"email"`
+	}
+
+	type Address struct {
+		CountryCode string `json:"country_code" valid:"ISO3166Alpha3"`
+	}
+
+	type Person struct {
+		Details   Details   `json:"details"`
+		Addresses []Address `json:"addresses"`
+	}
+
+	var tests = []struct {
+		param    interface{}
+		expected bool
+		expectedErr string
+	}{
+		{Person{
+			Details: Details{Email: "gogopher@example-com"},
+			Addresses: []Address{
+				{CountryCode: "GBP"},
+				{CountryCode: "AUS"},
+			},
+		}, false, "Addresses.0.country_code: GBP does not validate as ISO3166Alpha3;" +
+			"Details.email: gogopher@example-com does not validate as email"},
+	}
+
+	for _, test := range tests {
+		actual, err := ValidateStruct(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+		if err != nil {
+			if err.Error() != test.expectedErr {
+				t.Errorf("Got Error on ValidateStruct(%q). Expected: %s Actual: %s", test.param, test.expectedErr, err)
+			}
+		} else if test.expectedErr != "" {
+			t.Errorf("Expected error on ValidateStruct(%q).", test.param)
+		}
+	}
+}
+
 func TestValidatorIncludedInError(t *testing.T) {
 	post := Post{
 		Title:    "",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/402)
<!-- Reviewable:end -->
