### PR TITLE
Added option to allow validation of empty values by custom validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ import (
 
 `SetNilPtrAllowedByRequired` causes validation to pass when struct fields marked by `required` are set to nil. This is disabled by default for consistency, but some packages that need to be able to determine between `nil` and `zero value` state can use this. If disabled, both `nil` and `zero` values cause validation errors.
 
+`SetEmptyValueAllowed` causes custom validators to be allowed to validate empty values. This is disabled by default for backward compatiblity.
+
 ```go
 import "github.com/asaskevich/govalidator"
 

--- a/validator.go
+++ b/validator.go
@@ -25,6 +25,7 @@ import (
 var (
 	fieldsRequiredByDefault bool
 	nilPtrAllowedByRequired = false
+	emptyValueAllowed       = false
 	notNumberRegexp         = regexp.MustCompile("[^0-9]+")
 	whiteSpacesAndMinus     = regexp.MustCompile(`[\s-]+`)
 	paramsRegexp            = regexp.MustCompile(`\(.*\)$`)
@@ -61,6 +62,12 @@ func SetFieldsRequiredByDefault(value bool) {
 // By default this is disabled.
 func SetNilPtrAllowedByRequired(value bool) {
 	nilPtrAllowedByRequired = value
+}
+
+// SetEmptyValueAllowed causes custom validators to be allowed to validate empty values.
+// By default this is disabled.
+func SetEmptyValueAllowed(value bool) {
+	emptyValueAllowed = value
 }
 
 // IsEmail checks if the string is an email.
@@ -1323,7 +1330,7 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 		options = parseTagIntoMap(tag)
 	}
 
-	if isEmptyValue(v) {
+	if !emptyValueAllowed && isEmptyValue(v) {
 		// an empty value is not validated, checks only required
 		isValid, resultErr = checkRequired(v, t, options)
 		for key := range options {

--- a/validator_test.go
+++ b/validator_test.go
@@ -3594,3 +3594,89 @@ func TestIsIMSI(t *testing.T) {
 		}
 	}
 }
+
+func TestStringEmptyValue(t *testing.T) {
+	type EmptyIsInStruct struct {
+		IsIn string `valid:"required"`
+	}
+
+	var empty = ""
+	var normal = "123456"
+
+	var tests = []struct {
+		param       interface{}
+		expected    bool
+		expectedErr string
+	}{
+		{
+			EmptyIsInStruct{empty},
+			true,
+			"",
+		},
+		{
+			EmptyIsInStruct{normal},
+			true,
+			"",
+		},
+	}
+
+	SetEmptyValueAllowed(true)
+	for _, test := range tests {
+		actual, err := ValidateStruct(test.param)
+
+		if actual != test.expected {
+			t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+		if err != nil {
+			if err.Error() != test.expectedErr {
+				t.Errorf("Got Error on ValidateStruct(%q). Expected: %s Actual: %s", test.param, test.expectedErr, err)
+			}
+		} else if test.expectedErr != "" {
+			t.Errorf("Expected error on ValidateStruct(%q).", test.param)
+		}
+	}
+	SetEmptyValueAllowed(false)
+}
+
+func TestIntEmptyValue(t *testing.T) {
+	type EmptyIsInStruct struct {
+		IsIn int `valid:"required"`
+	}
+
+	var empty = 0
+	var normal = 123456
+
+	var tests = []struct {
+		param       interface{}
+		expected    bool
+		expectedErr string
+	}{
+		{
+			EmptyIsInStruct{empty},
+			true,
+			"",
+		},
+		{
+			EmptyIsInStruct{normal},
+			true,
+			"",
+		},
+	}
+
+	SetEmptyValueAllowed(true)
+	for _, test := range tests {
+		actual, err := ValidateStruct(test.param)
+
+		if actual != test.expected {
+			t.Errorf("Expected ValidateStruct(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+		if err != nil {
+			if err.Error() != test.expectedErr {
+				t.Errorf("Got Error on ValidateStruct(%q). Expected: %s Actual: %s", test.param, test.expectedErr, err)
+			}
+		} else if test.expectedErr != "" {
+			t.Errorf("Expected error on ValidateStruct(%q).", test.param)
+		}
+	}
+	SetEmptyValueAllowed(false)
+}


### PR DESCRIPTION
This feature is implemented as a new optional feature - it is not a breaking feature

You set it by calling the below method passing true:
`govalidator.SetEmptyValueAllowed(true)`


  * New feature, or refactor of existing code: master/develop branch

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix         | no
| BC Break      | no
| New Feature   | yes
| RFC           | yes
| QA            | yes

### Description

This change is necessary because the user of this package should be able to validate empty values.

  - How do you reproduce it?
Try and validate any empty value

  - What did you expect to happen?
for this package to call our custom validator even if its an empty value

  - What actually happened?
it does not call our custom validator - it returns false

- Are you adding documentation?
Yes I have updated the readme

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
I have added 2 additional tests. This feature is implemented as a new optional feature - it is not a breaking feature

  - Explain why the changes are necessary:
Because we should be able to validate empty values if we want to

  - TARGET THE master BRANCH
Yes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/409)
<!-- Reviewable:end -->
