### PR TITLE
fix credit card bug which accepted string alphabets #416

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -27,6 +27,7 @@ var (
 	nilPtrAllowedByRequired = false
 	notNumberRegexp         = regexp.MustCompile("[^0-9]+")
 	whiteSpacesAndMinus     = regexp.MustCompile(`[\s-]+`)
+	whiteSpacesAndMinusMultiStickied = regexp.MustCompile(`[\s-]{2,}`)
 	paramsRegexp            = regexp.MustCompile(`\(.*\)$`)
 )
 
@@ -363,7 +364,10 @@ func IsUUID(str string) bool {
 
 // IsCreditCard checks if the string is a credit card.
 func IsCreditCard(str string) bool {
-	sanitized := notNumberRegexp.ReplaceAllString(str, "")
+	if whiteSpacesAndMinusMultiStickied.MatchString(str) {
+		return false
+	}
+	sanitized := whiteSpacesAndMinus.ReplaceAllString(str, "")
 	if !rxCreditCard.MatchString(sanitized) {
 		return false
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -1430,6 +1430,10 @@ func TestIsCreditCard(t *testing.T) {
 	}{
 		{"empty", "", false},
 		{"not numbers", "credit card", false},
+		{"has alphabet character's", "26f71e56d2e54fabae2ca87e5c524fef", false},
+		{"has dashes stickied together", "26715--62542--875524", false},
+		{"has spaces stickied together", "26715  6254287  5524", false},
+		{"has spaces stickied with dash", "26715 62542- 875524", false},
 		{"invalid luhn algorithm", "4220855426213389", false},
 
 		{"visa", "4220855426222389", true},


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: master/develop branch
--> Bugfix: master branch  #416

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix         | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
now the Credit card validation rejects non-numeric characters and just accept spaces & dashes which are placed individually
Example:
these following credit cards returned false:
<pre>
"26f71e56d2e54fabae2ca87e5c524fef"
"26715--62542--875524"
"26715   625428755  24" 
"26715 -62542-875524"
</pre>   

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
- fixing a bug with unit tests to demonstrate it
- How do you reproduce it?
  - by modifying IsCreditCard() function in validator.go
  - What did you expect to happen?
  - remove only spaces and dashes instead of all non-numeric characters
  - What actually happened?
  - for all given credit cards it just omitted every thing except numbers
  - TARGET THE master BRANCH
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/420)
<!-- Reviewable:end -->
