### PR TITLE
added validator for E164

### DIFF
--- a/patterns.go
+++ b/patterns.go
@@ -50,6 +50,7 @@ const (
 	hasWhitespaceOnly string = "^[[:space:]]+$"
 	IMEI              string = "^[0-9a-f]{14}$|^\\d{15}$|^\\d{18}$"
 	IMSI              string = "^\\d{14,15}$"
+	E164              string = `^\+?[1-9]\d{1,14}$`
 )
 
 // Used by IsFilePath func
@@ -104,4 +105,5 @@ var (
 	rxHasWhitespaceOnly = regexp.MustCompile(hasWhitespaceOnly)
 	rxIMEI              = regexp.MustCompile(IMEI)
 	rxIMSI              = regexp.MustCompile(IMSI)
+	rxE164              = regexp.MustCompile(E164)
 )

--- a/validator.go
+++ b/validator.go
@@ -1625,3 +1625,7 @@ func (sv stringValues) Len() int           { return len(sv) }
 func (sv stringValues) Swap(i, j int)      { sv[i], sv[j] = sv[j], sv[i] }
 func (sv stringValues) Less(i, j int) bool { return sv.get(i) < sv.get(j) }
 func (sv stringValues) get(i int) string   { return sv[i].String() }
+
+func IsE164(str string) bool {
+	return rxE164.MatchString(str)
+}

--- a/validator_test.go
+++ b/validator_test.go
@@ -3594,3 +3594,24 @@ func TestIsIMSI(t *testing.T) {
 		}
 	}
 }
+
+func TestIsE164(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		param    string
+		expected bool
+	}{
+		{"+14155552671", true},
+		{"+442071838750", true},
+		{"+551155256325", true},
+		{"+226071234567 ", false},
+		{"+06071234567 ", false},
+	}
+	for _, test := range tests {
+		actual := IsE164(test.param)
+		if actual != test.expected {
+			t.Errorf("Expected IsURL(%q) to be %v, got %v", test.param, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
I added E164 validator for phone numbers in this repo. Also wrote a test to check whether it works or not in validator_test.go file.
Changes I made are: added proper E164 regex in patterns.go and then added a function in validator.go to check whether if phone number has E164 format or not.