### PR TITLE
Refactored typeCheck to accept parent, fixing array/slice failing required check with empty values

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -923,7 +923,7 @@ func ValidateMap(s map[string]interface{}, m map[string]interface{}) (bool, erro
 				Offset:    0,
 				Index:     []int{index},
 				Anonymous: false,
-			}, val, nil)
+			}, val, nil, val)
 			if err != nil {
 				errs = append(errs, err)
 			}
@@ -1001,7 +1001,7 @@ func ValidateStruct(s interface{}) (bool, error) {
 				errs = append(errs, err)
 			}
 		}
-		resultField, err2 := typeCheck(valueField, typeField, val, nil)
+		resultField, err2 := typeCheck(valueField, typeField, val, nil, val)
 		if err2 != nil {
 
 			// Replace structure name with JSON name if there is a tag on the variable
@@ -1297,7 +1297,7 @@ func checkRequired(v reflect.Value, t reflect.StructField, options tagOptionsMap
 	return true, nil
 }
 
-func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options tagOptionsMap) (isValid bool, resultErr error) {
+func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options tagOptionsMap, p reflect.Value) (isValid bool, resultErr error) {
 	if !v.IsValid() {
 		return false, nil
 	}
@@ -1324,10 +1324,15 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 	}
 
 	if isEmptyValue(v) {
-		// an empty value is not validated, checks only required
-		isValid, resultErr = checkRequired(v, t, options)
-		for key := range options {
-			delete(options, key)
+		if p.Kind() == reflect.Slice || p.Kind() == reflect.Array && p.Len() > 0 {
+			// empty values are allowed for elements of arrays/slices, the parent has already been checked against the zero type
+			return true, nil
+		} else {
+			// an empty value is not validated, checks only required
+			isValid, resultErr = checkRequired(v, t, options)
+			for key := range options {
+				delete(options, key)
+			}
 		}
 		return isValid, resultErr
 	}
@@ -1503,7 +1508,7 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 			var resultItem bool
 			var err error
 			if v.MapIndex(k).Kind() != reflect.Struct {
-				resultItem, err = typeCheck(v.MapIndex(k), t, o, options)
+				resultItem, err = typeCheck(v.MapIndex(k), t, o, options, v)
 				if err != nil {
 					return false, err
 				}
@@ -1523,7 +1528,7 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 			var resultItem bool
 			var err error
 			if v.Index(i).Kind() != reflect.Struct {
-				resultItem, err = typeCheck(v.Index(i), t, o, options)
+				resultItem, err = typeCheck(v.Index(i), t, o, options, v)
 				if err != nil {
 					return false, err
 				}
@@ -1548,7 +1553,7 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 		if v.IsNil() {
 			return true, nil
 		}
-		return typeCheck(v.Elem(), t, o, options)
+		return typeCheck(v.Elem(), t, o, options, v)
 	case reflect.Struct:
 		return true, nil
 	default:
@@ -1563,7 +1568,7 @@ func stripParams(validatorString string) string {
 // isEmptyValue checks whether value empty or not
 func isEmptyValue(v reflect.Value) bool {
 	switch v.Kind() {
-	case reflect.String, reflect.Array:
+	case reflect.String:
 		return v.Len() == 0
 	case reflect.Map, reflect.Slice:
 		return v.Len() == 0 || v.IsNil()

--- a/validator_test.go
+++ b/validator_test.go
@@ -2965,6 +2965,7 @@ type testByteMap map[byte]byte
 type testByteSlice []byte
 type testStringStringMap map[string]string
 type testStringIntMap map[string]int
+type testIntArray [8]int
 
 func TestRequired(t *testing.T) {
 
@@ -3026,6 +3027,14 @@ func TestRequired(t *testing.T) {
 		},
 		{
 			struct {
+				TestIntArray testIntArray `valid:"required"`
+			}{
+				testIntArray{0, 1, 2, 3, 4, 5, 6, 7},
+			},
+			true,
+		},
+		{
+			struct {
 				TestByteArray testByteArray `valid:"required"`
 			}{},
 			false,
@@ -3042,7 +3051,7 @@ func TestRequired(t *testing.T) {
 			struct {
 				TestByteArray testByteArray `valid:"required"`
 			}{
-				testByteArray{'1', '2', '3', '4', '5', '6', '7', 'A'},
+				testByteArray{0x00, '1', '2', '3', '4', '5', '6', '7'},
 			},
 			true,
 		},


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix         | yes
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Related too https://github.com/asaskevich/govalidator/issues/334, the root cause seems to be that each element of an array is checked with `isEmptyValue` and fails the `required` check if it is empty. Meaning that an array of bytes containing a zero value of the byte type (`0x00`) will trigger the failure. Solution is to check the array against the zero type first, then ignore any empty values upon digging into each individual element of `byte` array. I've added a test to reproduce.

Note: `IsExistingEmail` tests fail for me on a fresh pull from `master`.

This is just a quick hack together, I welcome some advice on the direction here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/436)
<!-- Reviewable:end -->
