### PR TITLE
ref: #441. validation for negative integer range

### DIFF
--- a/types.go
+++ b/types.go
@@ -74,7 +74,7 @@ var ParamTagMap = map[string]ParamValidator{
 
 // ParamTagRegexMap maps param tags to their respective regexes.
 var ParamTagRegexMap = map[string]*regexp.Regexp{
-	"range":           regexp.MustCompile("^range\\((\\d+)\\|(\\d+)\\)$"),
+	"range":           regexp.MustCompile("^range\\((-?\\d+)\\|(-?\\d+)\\)$"),
 	"length":          regexp.MustCompile("^length\\((\\d+)\\|(\\d+)\\)$"),
 	"runelength":      regexp.MustCompile("^runelength\\((\\d+)\\|(\\d+)\\)$"),
 	"stringlength":    regexp.MustCompile("^stringlength\\((\\d+)\\|(\\d+)\\)$"),

--- a/validator_test.go
+++ b/validator_test.go
@@ -3442,11 +3442,12 @@ func ExampleValidateStruct() {
 
 func TestValidateStructParamValidatorInt(t *testing.T) {
 	type Test1 struct {
-		Int   int   `valid:"range(1|10)"`
-		Int8  int8  `valid:"range(1|10)"`
-		Int16 int16 `valid:"range(1|10)"`
-		Int32 int32 `valid:"range(1|10)"`
-		Int64 int64 `valid:"range(1|10)"`
+		Int    int   `valid:"range(1|10)"`
+		Int8   int8  `valid:"range(1|10)"`
+		Int16  int16 `valid:"range(1|10)"`
+		Int32  int32 `valid:"range(1|10)"`
+		Int64  int64 `valid:"range(1|10)"`
+		NegInt int   `valid:"range(-1|-10)"`
 
 		Uint   uint   `valid:"range(1|10)"`
 		Uint8  uint8  `valid:"range(1|10)"`
@@ -3457,8 +3458,8 @@ func TestValidateStructParamValidatorInt(t *testing.T) {
 		Float32 float32 `valid:"range(1|10)"`
 		Float64 float64 `valid:"range(1|10)"`
 	}
-	test1Ok := &Test1{5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5}
-	test1NotOk := &Test1{11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11}
+	test1Ok := &Test1{5, 5, 5, 5, 5, -5, 5, 5, 5, 5, 5, 5, 5}
+	test1NotOk := &Test1{11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11}
 
 	_, err := ValidateStruct(test1Ok)
 	if err != nil {


### PR DESCRIPTION
Fixes: #441 
  * New feature, validation for -ve integer range


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix         | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description


Tell us about why this change is necessary:

Added validation for -ve integer values on `range` tag.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/442)
<!-- Reviewable:end -->
