### PR TITLE
Empty string is a valid Base64 string

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -577,7 +577,7 @@ func IsVariableWidth(str string) bool {
 
 // IsBase64 checks if a string is base64 encoded.
 func IsBase64(str string) bool {
-	return rxBase64.MatchString(str)
+	return str == "" || rxBase64.MatchString(str)
 }
 
 // IsFilePath checks is a string is Win or Unix file path and returns it's type.

--- a/validator_test.go
+++ b/validator_test.go
@@ -1727,7 +1727,7 @@ func TestIsBase64(t *testing.T) {
 			"QmcL2a6hNOyu0ixX/x2kSFXApEnVrJ+/IxGyfyw8kf4N2IZpW5nEP847lpfj0SZZ" +
 			"Fwrd1mnfnDbYohX2zRptLy2ZUn06Qo9pkG5ntvFEPo9bfZeULtjYzIl6K8gJ2uGZ" + "HQIDAQAB", true},
 		{"12345", false},
-		{"", false},
+		{"", true},
 		{"Vml2YW11cyBmZXJtZtesting123", false},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix         | yes
| BC Break      | 🤷 
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Empty strings are valid base64 strings. If you base64 encode an empty string, you get an empty string.
A few example:
- https://stackoverflow.com/questions/15212127/is-an-empty-string-valid-base64-encoded-data-of-zero-bytes-length
- Warning, the most authoritative of all, https://chat.openai.com/share/33c6f549-4e9f-489f-8ea7-aa38fc697c2b

A python example: 
```python
>>> import base64
>>> base64.b64decode("")
b''
```

If you don't want empty strings, you can change the minLength.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/493)
<!-- Reviewable:end -->
