### PR TITLE
chore: version go module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/asaskevich/govalidator
+module github.com/asaskevich/govalidator/v11
 
 go 1.13


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------

| BC Break      | yes


### Description

#### Expected behavior

`go get gopkg.in/asaskevich/govalidator v11.0.1`  and `go get gopkg.in/asaskevich/govalidator.v11` should work 

#### Current behavior

```
go get gopkg.in/asaskevich/govalidator.v11                                                                                  
go: gopkg.in/asaskevich/govalidator.v11@v11.0.1: invalid version: go.mod has non-....v11 module path "github.com/asaskevich/govalidator" at revision v11.0.1

go get gopkg.in/asaskevich/govalidator v11.0.1                                                                                 
go: gopkg.in/asaskevich/govalidator: unrecognized import path "gopkg.in": parse https://gopkg.in/?go-get=1: no go-import meta tags ()
go: unrecognized import path "v11.0.1": https fetch: Get "https://v11.0.1/?go-get=1": dial tcp: lookup v11.0.1: no such host
```

### Related Issue
https://github.com/asaskevich/govalidator/issues/496