### PR TITLE
Add IsJWT validation function, tests, and README entry (Fixes #502)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ func IsIn(str string, params ...string) bool
 func IsInRaw(str string, params ...string) bool
 func IsInt(str string) bool
 func IsJSON(str string) bool
+func IsJWT(str string) bool
 func IsLatitude(str string) bool
 func IsLongitude(str string) bool
 func IsLowerCase(str string) bool

--- a/validator.go
+++ b/validator.go
@@ -28,6 +28,7 @@ var (
 	notNumberRegexp         = regexp.MustCompile("[^0-9]+")
 	whiteSpacesAndMinus     = regexp.MustCompile(`[\s-]+`)
 	paramsRegexp            = regexp.MustCompile(`\(.*\)$`)
+	rxJWT                   = regexp.MustCompile(`^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$`)
 )
 
 const maxURLRuneCount = 2083
@@ -578,6 +579,10 @@ func IsVariableWidth(str string) bool {
 // IsBase64 checks if a string is base64 encoded.
 func IsBase64(str string) bool {
 	return rxBase64.MatchString(str)
+}
+// `IsJWT(str string)` – Check if the string is a valid JSON Web Token
+func IsJWT(str string) bool {
+    return rxJWT.MatchString(str)
 }
 
 // IsFilePath checks is a string is Win or Unix file path and returns it's type.

--- a/validator_test.go
+++ b/validator_test.go
@@ -2634,6 +2634,18 @@ func TestFieldsRequiredByDefaultButExemptStruct(t *testing.T) {
 	SetFieldsRequiredByDefault(false)
 }
 
+func TestIsJWT(t *testing.T) {
+    validJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    invalidJWT := "not.a.valid.jwt"
+
+    if !IsJWT(validJWT) {
+        t.Errorf("Expected IsJWT(%v) to be true", validJWT)
+    }
+    if IsJWT(invalidJWT) {
+        t.Errorf("Expected IsJWT(%v) to be false", invalidJWT)
+    }
+}
+
 func TestFieldsRequiredByDefaultButExemptOrOptionalStruct(t *testing.T) {
 	var tests = []struct {
 		param    FieldsRequiredByDefaultButExemptOrOptionalStruct


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | yes
| QA            | yes

### Description

This PR adds a new validator function `IsJWT()` to the govalidator package.

**Why this change is necessary:**
Currently, JWT strings can only be validated using a manual regex inside a `valid:"matches(...)"` struct tag, which is not very convenient or readable. As per RFC-7519, a JWT is represented as a sequence of three URL-safe base64-encoded strings separated by periods ('.'). This PR implements a native validation function to improve developer ergonomics and code readability.

**What this PR does:**
- Implements a new `IsJWT()` function using a compiled regex pattern.
- Adds corresponding unit tests in `validator_test.go`.
- Updates the `README.md` function list to include the new `IsJWT()` function.

**Target branch:** master

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/506)
<!-- Reviewable:end -->
