### PR TITLE
fix(507): Add Unicode/IDN domain support to IsURL function

### DIFF
--- a/patterns.go
+++ b/patterns.go
@@ -37,8 +37,8 @@ const (
 	URLPath           string = `((\/|\?|#)[^\s]*)`
 	URLPort           string = `(:(\d{1,5}))`
 	URLIP             string = `([1-9]\d?|1\d\d|2[01]\d|22[0-3]|24\d|25[0-5])(\.(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])){2}(?:\.([0-9]\d?|1\d\d|2[0-4]\d|25[0-5]))`
-	URLSubdomain      string = `((www\.)|([a-zA-Z0-9]+([-_\.]?[a-zA-Z0-9])*[a-zA-Z0-9]\.[a-zA-Z0-9]+))`
-	URL                      = `^` + URLSchema + `?` + URLUsername + `?` + `((` + URLIP + `|(\[` + IP + `\])|(([a-zA-Z0-9]([a-zA-Z0-9-_]+)?[a-zA-Z0-9]([-\.][a-zA-Z0-9]+)*)|(` + URLSubdomain + `?))?(([a-zA-Z\x{00a1}-\x{ffff}0-9]+-?-?)*[a-zA-Z\x{00a1}-\x{ffff}0-9]+)(?:\.([a-zA-Z\x{00a1}-\x{ffff}]{1,}))?))\.?` + URLPort + `?` + URLPath + `?$`
+	URLSubdomain      string = `((www\.)|([a-zA-Z\x{00a1}-\x{ffff}0-9]+([-_\.]?[a-zA-Z\x{00a1}-\x{ffff}0-9])*[a-zA-Z\x{00a1}-\x{ffff}0-9]\.[a-zA-Z\x{00a1}-\x{ffff}0-9]+))`
+	URL                      = `^` + URLSchema + `?` + URLUsername + `?` + `((` + URLIP + `|(\[` + IP + `\])|(([a-zA-Z\x{00a1}-\x{ffff}0-9]([a-zA-Z\x{00a1}-\x{ffff}0-9-_]+)?[a-zA-Z\x{00a1}-\x{ffff}0-9]([-\.][a-zA-Z\x{00a1}-\x{ffff}0-9]+)*)|(` + URLSubdomain + `?))?(([a-zA-Z\x{00a1}-\x{ffff}0-9]+-?-?)*[a-zA-Z\x{00a1}-\x{ffff}0-9]+)(?:\.([a-zA-Z\x{00a1}-\x{ffff}]{1,}))?))\.?` + URLPort + `?` + URLPath + `?$`
 	SSN               string = `^\d{3}[- ]?\d{2}[- ]?\d{4}$`
 	WinPath           string = `^[a-zA-Z]:\\(?:[^\\/:*?"<>|\r\n]+\\)*[^\\/:*?"<>|\r\n]*$`
 	UnixPath          string = `^(/[^/\x00]*)+/?$`

--- a/validator_test.go
+++ b/validator_test.go
@@ -876,6 +876,9 @@ func TestIsURL(t *testing.T) {
 		{"foo_bar-fizz-buzz:1313", true},
 		{"foo_bar-fizz-buzz:13:13", false},
 		{"foo_bar-fizz-buzz://1313", false},
+		{"http://ñandú.com.ar", true},
+		{"https://ñandú.com.ar", true},
+		{"http://xn--and-6ma2c.com.ar", true},
 	}
 	for _, test := range tests {
 		actual := IsURL(test.param)


### PR DESCRIPTION
This pull request addresses issue #507 by adding Unicode/IDN (Internationalized Domain Names) support to the IsURL function.

**Changes:**
- Updated URLSubdomain and URL regex patterns in `patterns.go` to include Unicode character ranges (\x{00a1}-\x{ffff})
- Added test cases in `validator_test.go` to verify Unicode domain validation works correctly
- Tests include domains with Unicode characters like "ñandú.com.ar" and punycode equivalent "xn--and-6ma2c.com.ar"

**Why this change is needed:**
- The current IsURL function only supports ASCII characters in domain names
- Many websites use internationalized domain names with Unicode characters
- This enhancement makes the validator more inclusive and supports modern web standards

**Testing:**
- Added comprehensive test cases covering Unicode domain scenarios
- Verified both Unicode and punycode representations are properly validated

Fixes #507

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/509)
<!-- Reviewable:end -->
