### PR TITLE
Use json.Valid for JSON check

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -521,10 +521,9 @@ func IsISBN(str string, version int) bool {
 	return IsISBN(str, 10) || IsISBN(str, 13)
 }
 
-// IsJSON checks if the string is valid JSON (note: uses json.Unmarshal).
+// IsJSON checks if the string is valid JSON.
 func IsJSON(str string) bool {
-	var js json.RawMessage
-	return json.Unmarshal([]byte(str), &js) == nil
+	return json.Valid([]byte(str))
 }
 
 // IsMultibyte checks if the string contains one or more multibyte chars. Empty string is valid.


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix         | no
| BC Break      | no expected
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This follows up on #6 from 2014 and further optimizes the JSON check to `json.Valid` from stdlib.

`json.Valid` was introduced in Go 1.9 (August, 2017) and exports the private `checkValid`, which is the same validation function used by `json.Unmarshal`, in the json package. Therefore, it is expected to break no current usage, while saving the cost of allocating and copying data to the `json.RawMessage`.

We declared Go 1.13 in `go.mod`, and basically to this date, any active Go project that wants to update their dependencies will not be using Go 1.9 or earlier. So there will be no version concerns.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/510)
<!-- Reviewable:end -->
