### PR TITLE
fix: reject URLs with missing colon in scheme (http// https//)

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -105,6 +105,11 @@ func IsURL(str string) bool {
 	if str == "" || utf8.RuneCountInString(str) >= maxURLRuneCount || len(str) <= minURLRuneCount || strings.HasPrefix(str, ".") {
 		return false
 	}
+	// Reject strings that look like a scheme but are missing the colon,
+	// e.g. "http//example.com" or "https//example.com".
+	if (strings.HasPrefix(str, "http//") || strings.HasPrefix(str, "https//")) {
+		return false
+	}
 	strTemp := str
 	if strings.Contains(str, ":") && !strings.Contains(str, "://") {
 		// support no indicated urlscheme but with colon for port number

--- a/validator_test.go
+++ b/validator_test.go
@@ -876,6 +876,9 @@ func TestIsURL(t *testing.T) {
 		{"foo_bar-fizz-buzz:1313", true},
 		{"foo_bar-fizz-buzz:13:13", false},
 		{"foo_bar-fizz-buzz://1313", false},
+		// Missing colon in scheme (#494)
+		{"http//abc.com", false},
+		{"https//abc.com", false},
 	}
 	for _, test := range tests {
 		actual := IsURL(test.param)


### PR DESCRIPTION
Fixes #494

## Problem

`IsURL("http//abc.com")` returns `true`. Go's `url.Parse` is very lenient and accepts this, and the regex doesn't enforce `://`.

## Fix

Add an explicit check to reject strings starting with `http//` or `https//` (missing the colon separator).

## Tests

Added test cases for `http//abc.com` and `https//abc.com`. All existing tests pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/511)
<!-- Reviewable:end -->
