### PR TITLE
fix: reject URLs with scheme-like prefix missing colon (e.g. "http//")

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -105,6 +105,12 @@ func IsURL(str string) bool {
 	if str == "" || utf8.RuneCountInString(str) >= maxURLRuneCount || len(str) <= minURLRuneCount || strings.HasPrefix(str, ".") {
 		return false
 	}
+	// Reject strings that look like a scheme without the colon (e.g. "http//")
+	for _, scheme := range []string{"http//", "https//", "ftp//", "tcp//", "udp//", "ws//", "wss//"} {
+		if strings.HasPrefix(strings.ToLower(str), scheme) {
+			return false
+		}
+	}
 	strTemp := str
 	if strings.Contains(str, ":") && !strings.Contains(str, "://") {
 		// support no indicated urlscheme but with colon for port number


### PR DESCRIPTION
Fixes #494

## Problem

`IsURL("http//abc.com")` returns `true`. The URL schema regex is optional, so when `http://` fails to match (missing colon), the schema is skipped and `http//abc.com` is treated as a hostname.

## Fix

Add an explicit early check for common scheme names (`http`, `https`, `ftp`, `tcp`, `udp`, `ws`, `wss`) followed by `//` without the required `:` separator. These are rejected before reaching the regex.

## Testing

All existing tests pass. New cases:

```go
IsURL("http//abc.com")  // false ✅ (was: true)
IsURL("ftp//abc.com")   // false ✅ (was: true)
IsURL("http://abc.com") // true  ✅
IsURL("abc.com")        // true  ✅
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/512)
<!-- Reviewable:end -->
