### PR TITLE
Accept domain labels with multiple consecutive hyphens in IsURL

### DIFF
--- a/patterns.go
+++ b/patterns.go
@@ -38,7 +38,7 @@ const (
 	URLPort           string = `(:(\d{1,5}))`
 	URLIP             string = `([1-9]\d?|1\d\d|2[01]\d|22[0-3]|24\d|25[0-5])(\.(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])){2}(?:\.([0-9]\d?|1\d\d|2[0-4]\d|25[0-5]))`
 	URLSubdomain      string = `((www\.)|([a-zA-Z\x{00a1}-\x{ffff}0-9]+([-_\.]?[a-zA-Z\x{00a1}-\x{ffff}0-9])*[a-zA-Z\x{00a1}-\x{ffff}0-9]\.[a-zA-Z\x{00a1}-\x{ffff}0-9]+))`
-	URL                      = `^` + URLSchema + `?` + URLUsername + `?` + `((` + URLIP + `|(\[` + IP + `\])|(([a-zA-Z\x{00a1}-\x{ffff}0-9]([a-zA-Z\x{00a1}-\x{ffff}0-9-_]+)?[a-zA-Z\x{00a1}-\x{ffff}0-9]([-\.][a-zA-Z\x{00a1}-\x{ffff}0-9]+)*)|(` + URLSubdomain + `?))?(([a-zA-Z\x{00a1}-\x{ffff}0-9]+-?-?)*[a-zA-Z\x{00a1}-\x{ffff}0-9]+)(?:\.([a-zA-Z\x{00a1}-\x{ffff}]{1,}))?))\.?` + URLPort + `?` + URLPath + `?$`
+	URL                      = `^` + URLSchema + `?` + URLUsername + `?` + `((` + URLIP + `|(\[` + IP + `\])|(([a-zA-Z\x{00a1}-\x{ffff}0-9]([a-zA-Z\x{00a1}-\x{ffff}0-9-_]+)?[a-zA-Z\x{00a1}-\x{ffff}0-9]([-\.][a-zA-Z\x{00a1}-\x{ffff}0-9]+)*)|(` + URLSubdomain + `?))?(([a-zA-Z\x{00a1}-\x{ffff}0-9]+-*)*[a-zA-Z\x{00a1}-\x{ffff}0-9]+)(?:\.([a-zA-Z\x{00a1}-\x{ffff}]{1,}))?))\.?` + URLPort + `?` + URLPath + `?$`
 	SSN               string = `^\d{3}[- ]?\d{2}[- ]?\d{4}$`
 	WinPath           string = `^[a-zA-Z]:\\(?:[^\\/:*?"<>|\r\n]+\\)*[^\\/:*?"<>|\r\n]*$`
 	UnixPath          string = `^(/[^/\x00]*)+/?$`

--- a/validator_test.go
+++ b/validator_test.go
@@ -820,7 +820,9 @@ func TestIsURL(t *testing.T) {
 		{"http://foobar.com/t$-_.+!*\\'(),", true},
 		{"http://www.foobar.com/~foobar", true},
 		{"http://www.-foobar.com/", false},
-		{"http://www.foo---bar.com/", false},
+		// Domain labels may contain runs of hyphens (RFC 1035 §2.3.1);
+		// only a leading or trailing hyphen is invalid. See #386.
+		{"http://www.foo---bar.com/", true},
 		{"http://r6---snnvoxuioq6.googlevideo.com", true},
 		{"mailto:someone@example.com", true},
 		{"irc://irc.server.org/channel", false},


### PR DESCRIPTION
Closes #386. The URL regex's domain segment used `-?-?` inside a label, so any host with three or more consecutive hyphens — `www.exa---mpl.com` from the issue, or real-world hosts like `r6---snnvoxuioq6.googlevideo.com` — fell through to `false`. RFC 1035 §2.3.1 only forbids hyphens at the start or end of a label; runs in the middle are fine.

Switched the inner segment to `[a-zA-Z\x{00a1}-\x{ffff}0-9]+-*` so any number of hyphens between alphanumeric runs is accepted. The existing test for `foo---bar.com` expected `false` while the very next case (`r6---snnvoxuioq6.googlevideo.com`) already expected `true`, which was inconsistent — updated the former to `true` and noted the RFC reference.

Closes #386

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asaskevich/govalidator/513)
<!-- Reviewable:end -->
